### PR TITLE
Add filesystem helper classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: "Build"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 13 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          # refresh cache every month to avoid unlimited growth
+          key: maven-repo-jdk-${{ matrix.java }}-${{ steps.get-date.outputs.date }}
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        run: export LANG=en_US && mvn -B clean install -Dno-format
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -rf ~/.m2/repository/io/quarkus/quarkus-fs-util*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+/target/
+/.cache/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>39</version>
+    </parent>
+
+    <groupId>io.quarkus.fs</groupId>
+    <artifactId>quarkus-fs-util</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Quarkus - FS Util</name>
+
+    <description>Quarkus Filesystem Utils</description>
+    <url>https://quarkus.io/</url>
+    <developers>
+        <developer>
+            <id>quarkus</id>
+            <name>Quarkus Community</name>
+            <organization>Quarkus</organization>
+            <organizationUrl>https://quarkus.io</organizationUrl>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <url>https://github.com/quarkusio/quarkus-fs-util</url>
+        <connection>scm:git:git@github.com:quarkusio/quarkus-fs-util.git</connection>
+        <developerConnection>scm:git:git@github.com:quarkusio/quarkus-fs-util.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/quarkusio/quarkusfs-util/issues/</url>
+    </issueManagement>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+
+        <junit.jupiter.version>5.8.1</junit.jupiter.version>
+        <quarkus.version>2.5.0.Final</quarkus.version>
+
+        <formatter-maven-plugin.version>2.17.0</formatter-maven-plugin.version>
+        <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>
+        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+    </properties>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-release</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>${formatter-maven-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <artifactId>quarkus-ide-config</artifactId>
+                            <groupId>io.quarkus</groupId>
+                            <version>${quarkus.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <!-- store outside of target to speed up formatting when mvn clean is used -->
+                        <cachedir>.cache</cachedir>
+                        <configFile>eclipse-format.xml</configFile>
+                        <lineEnding>LF</lineEnding>
+                        <skip>${format.skip}</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>${impsort-maven-plugin.version}</version>
+                    <configuration>
+                        <!-- store outside of target to speed up formatting when mvn clean is used -->
+                        <cachedir>.cache</cachedir>
+                        <removeUnused>true</removeUnused>
+                        <skip>${format.skip}</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire-plugin.version}</version>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <maven.home>${maven.home}</maven.home>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Can be removed once https://github.com/jboss/jboss-parent-pom/pull/108 is included in a release -->
+                        <id>compile-java13</id>
+                        <configuration combine.self="override">
+                            <release>13</release>
+                            <buildDirectory>${project.build.directory}</buildDirectory>
+                            <compileSourceRoots>${project.basedir}/src/main/java13</compileSourceRoots>
+                            <outputDirectory>${project.build.directory}/classes/META-INF/versions/13
+                            </outputDirectory>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>
+                                    ${project.build.directory}/classes/META-INF/versions/12
+                                </additionalClasspathElement>
+                                <additionalClasspathElement>
+                                    ${project.build.directory}/classes/META-INF/versions/11
+                                </additionalClasspathElement>
+                                <additionalClasspathElement>
+                                    ${project.build.directory}/classes/META-INF/versions/10
+                                </additionalClasspathElement>
+                                <additionalClasspathElement>
+                                    ${project.build.directory}/classes/META-INF/versions/9
+                                </additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.outputDirectory}
+                                </additionalClasspathElement>
+                            </additionalClasspathElements>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <serverId>ossrh</serverId>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <!-- ## IMPORTANT ## In your ~/.m2/settings.xml you
+                            need to add and edit the following profile: <profile> <id>release</id> <properties>
+                            <gpg.useagent>false</gpg.useagent> <gpg.executable>/usr/local/Cellar/gnupg@1.4/1.4.23_1/bin/gpg1</gpg.executable>
+                            <- use gpg1 on Mac OS X <gpg.homedir>~/.gnupg</gpg.homedir> <- Update to
+                            your own directory <gpg.passphrase>******</gpg.passphrase> <- Add your passphrase
+                            </properties> </profile> -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>format</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!no-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <configuration>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sort-imports</id>
+                                <goals>
+                                    <goal>sort</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>validate</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>no-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>validate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <configuration>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>check-imports</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/src/main/java/io/quarkus/fs/util/FileSystemHelper.java
+++ b/src/main/java/io/quarkus/fs/util/FileSystemHelper.java
@@ -1,0 +1,37 @@
+package io.quarkus.fs.util;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Map;
+
+public class FileSystemHelper {
+    /**
+     * Same as calling {@link FileSystems#newFileSystem(Path, ClassLoader)}. The env parameter is ignored when running on java
+     * versions less than 13.
+     * 
+     * @param path
+     * @param env only used on java 13
+     * @param classLoader
+     * @return
+     * @throws IOException
+     */
+    public static FileSystem openFS(Path path, Map<String, ?> env, ClassLoader classLoader) throws IOException {
+        return FileSystems.newFileSystem(path, classLoader);
+    }
+
+    /**
+     * Same as calling {@link FileSystems#newFileSystem(URI, Map, ClassLoader)}
+     * 
+     * @param uri
+     * @param env
+     * @param classLoader
+     * @return
+     * @throws IOException
+     */
+    public static FileSystem openFS(URI uri, Map<String, ?> env, ClassLoader classLoader) throws IOException {
+        return FileSystems.newFileSystem(uri, env, classLoader);
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/ZipUtils.java
@@ -1,0 +1,264 @@
+
+package io.quarkus.fs.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipError;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ZipUtils {
+
+    private static final String JAR_URI_PREFIX = "jar:";
+    private static final Map<String, Object> DEFAULT_OWNER_ENV = new HashMap<>();
+    private static final Map<String, Object> CREATE_ENV = new HashMap<>();
+
+    static {
+        String user = System.getProperty("user.name");
+        DEFAULT_OWNER_ENV.put("defaultOwner", user);
+        DEFAULT_OWNER_ENV.put("defaultGroup", user);
+
+        CREATE_ENV.putAll(DEFAULT_OWNER_ENV);
+        CREATE_ENV.put("create", "true");
+    }
+
+    public static void unzip(Path zipFile, Path targetDir) throws IOException {
+        try {
+            if (!Files.exists(targetDir)) {
+                Files.createDirectories(targetDir);
+            }
+        } catch (FileAlreadyExistsException fae) {
+            throw new IOException("Could not create directory '" + targetDir + "' as a file already exists with the same name");
+        }
+        try (FileSystem zipfs = newFileSystem(zipFile)) {
+            for (Path zipRoot : zipfs.getRootDirectories()) {
+                copyFromZip(zipRoot, targetDir);
+            }
+        } catch (IOException | ZipError ioe) {
+            // TODO: (at a later date) Get rid of the ZipError catching (and instead only catch IOException)
+            //  since it's a JDK bug which threw the undeclared ZipError instead of an IOException.
+            //  Java 9 fixes it https://bugs.openjdk.java.net/browse/JDK-8062754
+
+            throw new IOException("Could not unzip " + zipFile + " to target dir " + targetDir, ioe);
+        }
+    }
+
+    public static URI toZipUri(Path zipFile) throws IOException {
+        URI zipUri = zipFile.toUri();
+        try {
+            zipUri = new URI(JAR_URI_PREFIX + zipUri.getScheme(), zipUri.getPath(), null);
+        } catch (URISyntaxException e) {
+            throw new IOException("Failed to create a JAR URI for " + zipFile, e);
+        }
+        return zipUri;
+    }
+
+    public static void copyFromZip(Path source, Path target) throws IOException {
+        Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                            throws IOException {
+                        final Path targetDir = target.resolve(source.relativize(dir).toString());
+                        try {
+                            Files.copy(dir, targetDir);
+                        } catch (FileAlreadyExistsException e) {
+                            if (!Files.isDirectory(targetDir))
+                                throw e;
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                            throws IOException {
+                        Files.copy(file, target.resolve(source.relativize(file).toString()),
+                                StandardCopyOption.REPLACE_EXISTING);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+    }
+
+    public static void zip(Path src, Path zipFile) throws IOException {
+        try (FileSystem zipfs = newZip(zipFile)) {
+            if (Files.isDirectory(src)) {
+                try (DirectoryStream<Path> stream = Files.newDirectoryStream(src)) {
+                    for (Path srcPath : stream) {
+                        copyToZip(src, srcPath, zipfs);
+                    }
+                }
+            } else {
+                Files.copy(src, zipfs.getPath(src.getFileName().toString()), StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+
+    public static FileSystem newZip(Path zipFile) throws IOException {
+        final Map<String, Object> env;
+        if (Files.exists(zipFile)) {
+            env = DEFAULT_OWNER_ENV;
+        } else {
+            env = CREATE_ENV;
+            // explicitly create any parent dirs, since the ZipFileSystem only creates a new file
+            // with "create" = "true", but doesn't create any parent dirs.
+
+            // It's OK to not check the existence of the parent dir(s) first, since the API,
+            // as per its contract doesn't throw any exception if the parent dir(s) already exist
+            Files.createDirectories(zipFile.getParent());
+        }
+        try {
+            return FileSystemHelper.openFS(toZipUri(zipFile), env, null);
+        } catch (FileSystemAlreadyExistsException e) {
+            throw new IOException("fs already exists " + zipFile, e);
+        } catch (IOException ioe) {
+            // include the URI for which the filesystem creation failed
+            throw new IOException("Failed to create a new filesystem for " + zipFile, ioe);
+        }
+    }
+
+    private static void copyToZip(Path srcRoot, Path srcPath, FileSystem zipfs) throws IOException {
+        Files.walkFileTree(srcPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                new SimpleFileVisitor<Path>() {
+                    @Override
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                            throws IOException {
+                        final Path targetDir = zipfs.getPath(srcRoot.relativize(dir).toString());
+                        try {
+                            Files.copy(dir, targetDir);
+                        } catch (FileAlreadyExistsException e) {
+                            if (!Files.isDirectory(targetDir)) {
+                                throw e;
+                            }
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                            throws IOException {
+                        Files.copy(file, zipfs.getPath(srcRoot.relativize(file).toString()),
+                                StandardCopyOption.REPLACE_EXISTING);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+    }
+
+    /**
+     * This call is not thread safe, a single of FileSystem can be created for the
+     * profided uri until it is closed.
+     *
+     * @param uri The uri to the zip file.
+     * @param env Env map.
+     * @return A new FileSystem.
+     * @throws IOException in case of a failure
+     */
+    public static FileSystem newFileSystem(URI uri, Map<String, Object> env) throws IOException {
+        env = new HashMap<>(env);
+        env.putAll(DEFAULT_OWNER_ENV);
+
+        // If Multi threading required, logic should be added to wrap this fs
+        // onto a fs that handles a reference counter and close the fs only when all thread are done
+        // with it.
+        try {
+            return FileSystemHelper.openFS(uri, env, null);
+        } catch (FileSystemAlreadyExistsException e) {
+            throw new IOException("fs already exists " + uri, e);
+        } catch (IOException | ZipError ioe) {
+            // TODO: (at a later date) Get rid of the ZipError catching (and instead only catch IOException)
+            //  since it's a JDK bug which threw the undeclared ZipError instead of an IOException.
+            //  Java 9 fixes it https://bugs.openjdk.java.net/browse/JDK-8062754
+
+            // include the URI for which the filesystem creation failed
+            throw new IOException("Failed to create a new filesystem for " + uri, ioe);
+        }
+    }
+
+    /**
+     * This call is thread safe, a new FS is created for each invocation.
+     *
+     * @param path The zip file.
+     * @return A new FileSystem instance
+     * @throws IOException in case of a failure
+     */
+    public static FileSystem newFileSystem(final Path path) throws IOException {
+        try {
+            return FileSystemHelper.openFS(path, DEFAULT_OWNER_ENV, null);
+        } catch (FileSystemAlreadyExistsException e) {
+            throw new IOException("fs already exists " + path, e);
+        } catch (IOException ioe) {
+            // include the path for which the filesystem creation failed
+            throw new IOException("Failed to create a new filesystem for " + path, ioe);
+        }
+    }
+
+    public static FileSystem newFileSystem(final Path path, ClassLoader classLoader) throws IOException {
+        try {
+            return FileSystemHelper.openFS(path, DEFAULT_OWNER_ENV, classLoader);
+        } catch (FileSystemAlreadyExistsException e) {
+            throw new IOException("fs already exists " + path, e);
+        } catch (IOException ioe) {
+            // include the path for which the filesystem creation failed
+            throw new IOException("Failed to create a new filesystem for " + path, ioe);
+        }
+    }
+
+    /**
+     * This is a hack to get past the <a href="https://bugs.openjdk.java.net/browse/JDK-8232879">JDK-8232879</a>
+     * issue which causes CRC errors when writing out data to (jar) files using ZipFileSystem.
+     * TODO: Get rid of this method as soon as JDK-8232879 gets fixed and released in a public version
+     *
+     * @param original The original outputstream which will be wrapped into a new outputstream
+     *        that delegates to this one.
+     * @return
+     */
+    public static OutputStream wrapForJDK8232879(final OutputStream original) {
+        return new OutputStream() {
+            @Override
+            public void write(final byte[] b) throws IOException {
+                original.write(b, 0, b.length);
+            }
+
+            @Override
+            public void write(final byte[] b, final int off, final int len) throws IOException {
+                original.write(b, off, len);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                original.flush();
+            }
+
+            @Override
+            public void close() throws IOException {
+                original.close();
+            }
+
+            @Override
+            public void write(final int b) throws IOException {
+                // we call the 3 arg write(...) method here, instead
+                // of the single arg one to bypass the JDK-8232879 issue
+                final byte[] buf = new byte[1];
+                buf[0] = (byte) (b & 0xff);
+                this.write(buf, 0, 1);
+            }
+        };
+    }
+}

--- a/src/main/java13/io/quarkus/fs/util/FileSystemHelper.java
+++ b/src/main/java13/io/quarkus/fs/util/FileSystemHelper.java
@@ -1,0 +1,26 @@
+package io.quarkus.fs.util;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Map;
+
+public class FileSystemHelper {
+    /**
+     *
+     * @param path
+     * @param env
+     * @param classLoader
+     * @return
+     * @throws IOException
+     */
+    public static FileSystem openFS(Path path, Map<String, ?> env, ClassLoader classLoader) throws IOException {
+        return FileSystems.newFileSystem(path, env, classLoader);
+    }
+
+    public static FileSystem openFS(URI uri, Map<String, ?> env, ClassLoader classLoader) throws IOException {
+        return FileSystems.newFileSystem(uri, env, classLoader);
+    }
+}

--- a/src/test/java/io/quarkus/fs/util/ZipUtilsTest.java
+++ b/src/test/java/io/quarkus/fs/util/ZipUtilsTest.java
@@ -1,0 +1,108 @@
+package io.quarkus.fs.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ZipUtilsTest {
+
+    /**
+     * Test that when an operation on a corrupt zip file fails, the resulting IOException
+     * has the path details of the file/uri of the source file
+     *
+     * @throws Exception
+     * @see <a href="https://github.com/quarkusio/quarkus/issues/4126"/>
+     */
+    @Test
+    public void testCorruptZipException() throws Exception {
+        final Path tmpFile = Files.createTempFile(null, ".jar");
+        try {
+            final URI uri = new URI("jar", tmpFile.toUri().toString(), null);
+            try {
+                ZipUtils.newFileSystem(uri, Collections.emptyMap());
+                Assertions.fail("New filesystem creation was expected to fail for a non-zip file");
+            } catch (IOException ioe) {
+                // verify the exception message content
+                if (!ioe.getMessage().contains(uri.toString())) {
+                    throw ioe;
+                }
+            }
+
+            try {
+                ZipUtils.newFileSystem(tmpFile);
+                Assertions.fail("New filesystem creation was expected to fail for a non-zip file");
+            } catch (IOException ioe) {
+                // verify the exception message content
+                if (!ioe.getMessage().contains(tmpFile.toString())) {
+                    throw ioe;
+                }
+            }
+        } finally {
+            Files.delete(tmpFile);
+        }
+    }
+
+    /**
+     * Test that the {@link ZipUtils#newZip(Path)} works as expected
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNewZip() throws Exception {
+        final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        final Path zipPath = Paths.get(tmpDir.toString(), "ziputilstest-" + System.currentTimeMillis() + ".jar");
+        try {
+            try (final FileSystem fs = ZipUtils.newZip(zipPath)) {
+                final Path someFileInZip = fs.getPath("hello.txt");
+                Files.write(someFileInZip, "hello".getBytes(StandardCharsets.UTF_8));
+            }
+            // now just verify that the content was actually written out
+            try (final FileSystem fs = ZipUtils.newFileSystem(zipPath)) {
+                assertFileExistsWithContent(fs.getPath("hello.txt"), "hello");
+            }
+        } finally {
+            Files.deleteIfExists(zipPath);
+        }
+    }
+
+    /**
+     * Tests that the {@link ZipUtils#newZip(Path)} works correctly, and creates the zip file,
+     * when the parent directories of the {@link Path} passed to it are not present.
+     *
+     * @throws Exception
+     * @see <a href="https://github.com/quarkusio/quarkus/issues/5680"/>
+     */
+    @Test
+    public void testNewZipForNonExistentParentDir() throws Exception {
+        final Path tmpDir = Files.createTempDirectory(null);
+        final Path nonExistentLevel1Dir = tmpDir.resolve("non-existent-level1");
+        final Path nonExistentLevel2Dir = nonExistentLevel1Dir.resolve("non-existent-level2");
+        final Path zipPath = Paths.get(nonExistentLevel2Dir.toString(), "ziputilstest-nonexistentdirs.jar");
+        try {
+            try (final FileSystem fs = ZipUtils.newZip(zipPath)) {
+                final Path someFileInZip = fs.getPath("hello.txt");
+                Files.write(someFileInZip, "hello".getBytes(StandardCharsets.UTF_8));
+            }
+            // now just verify that the content was actually written out
+            try (final FileSystem fs = ZipUtils.newFileSystem(zipPath)) {
+                assertFileExistsWithContent(fs.getPath("hello.txt"), "hello");
+            }
+        } finally {
+            Files.deleteIfExists(zipPath);
+        }
+    }
+
+    private static void assertFileExistsWithContent(final Path path, final String content) throws IOException {
+        final String readContent = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+        assertEquals(content, readContent, "Unexpected content in " + path);
+    }
+}


### PR DESCRIPTION
The changes here follow up https://github.com/quarkusio/quarkus/pull/21761.

* Setup the maven project itself, with an initial ci workflow.
* Copy the FIleSystemHelper and ZipUtils class into this project
* Build output is a MR Jar, which uses the `FileSystems.newFileSystem(path, env, classLoader)` on jdk13, but silently drops the env on jdk11.