### PR TITLE
Load FileSystemProviders with system cl

### DIFF
--- a/src/main/java/io/quarkus/fs/util/FileSystemProviders.java
+++ b/src/main/java/io/quarkus/fs/util/FileSystemProviders.java
@@ -9,11 +9,19 @@ public class FileSystemProviders {
     public static final FileSystemProvider ZIP_PROVIDER;
     static {
         FileSystemProvider foundZipProvider = null;
-        for (FileSystemProvider installedProvider : FileSystemProvider.installedProviders()) {
-            if (installedProvider.getScheme().equals("jar")) {
-                foundZipProvider = installedProvider;
-                break;
+        final ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+        try {
+            // We are loading "installed" FS providers that are loaded from the system classloader anyway
+            // To avoid potential ClassCastExceptions we are setting the context classloader to the system one
+            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
+            for (FileSystemProvider installedProvider : FileSystemProvider.installedProviders()) {
+                if (installedProvider.getScheme().equals("jar")) {
+                    foundZipProvider = installedProvider;
+                    break;
+                }
             }
+        } finally {
+            Thread.currentThread().setContextClassLoader(ccl);
         }
         ZIP_PROVIDER = foundZipProvider;
     }


### PR DESCRIPTION
The FSP are discovered using the system classloader. if a custom provider tries to load classes using `Thread.currentThread().getContextClassLoader().loadClass` a ClassCastException is thrown.

Same idea as was originally done in https://github.com/quarkusio/quarkus/pull/9774.
Moving the fix over to this lib, since I want to get rid of it in ClassPathUtils for future optimizations.
