### PR TITLE
Make ZFS writeability configurable using env

### DIFF
--- a/src/main/java/io/quarkus/fs/util/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/ZipUtils.java
@@ -38,6 +38,7 @@ public class ZipUtils {
 
         CREATE_ENV.putAll(DEFAULT_OWNER_ENV);
         CREATE_ENV.put("create", "true");
+        CREATE_ENV.put("writeable", "true");
     }
 
     public static void unzip(Path zipFile, Path targetDir) throws IOException {

--- a/src/main/java/io/quarkus/fs/util/zipfs/ByteArrayChannel.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ByteArrayChannel.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.util.Arrays;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class ByteArrayChannel implements SeekableByteChannel {
+
+    private final ReadWriteLock rwlock = new ReentrantReadWriteLock();
+    private byte buf[];
+
+    /*
+     * The current position of this channel.
+     */
+    private int pos;
+
+    /*
+     * The index that is one greater than the last valid byte in the channel.
+     */
+    private int last;
+
+    private boolean closed;
+    private boolean readonly;
+
+    /*
+     * Creates a {@code ByteArrayChannel} with size {@code sz}.
+     */
+    ByteArrayChannel(int sz, boolean readonly) {
+        this.buf = new byte[sz];
+        this.pos = this.last = 0;
+        this.readonly = readonly;
+    }
+
+    /*
+     * Creates a ByteArrayChannel with its 'pos' at 0 and its 'last' at buf's end.
+     * Note: no defensive copy of the 'buf', used directly.
+     */
+    ByteArrayChannel(byte[] buf, boolean readonly) {
+        this.buf = buf;
+        this.pos = 0;
+        this.last = buf.length;
+        this.readonly = readonly;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public long position() throws IOException {
+        beginRead();
+        try {
+            ensureOpen();
+            return pos;
+        } finally {
+            endRead();
+        }
+    }
+
+    @Override
+    public SeekableByteChannel position(long pos) throws IOException {
+        beginWrite();
+        try {
+            ensureOpen();
+            if (pos < 0 || pos >= Integer.MAX_VALUE)
+                throw new IllegalArgumentException("Illegal position " + pos);
+            this.pos = Math.min((int) pos, last);
+            return this;
+        } finally {
+            endWrite();
+        }
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        beginWrite();
+        try {
+            ensureOpen();
+            if (pos == last)
+                return -1;
+            int n = Math.min(dst.remaining(), last - pos);
+            dst.put(buf, pos, n);
+            pos += n;
+            return n;
+        } finally {
+            endWrite();
+        }
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long size) throws IOException {
+        if (readonly)
+            throw new NonWritableChannelException();
+        ensureOpen();
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        if (readonly)
+            throw new NonWritableChannelException();
+        beginWrite();
+        try {
+            ensureOpen();
+            int n = src.remaining();
+            ensureCapacity(pos + n);
+            src.get(buf, pos, n);
+            pos += n;
+            if (pos > last) {
+                last = pos;
+            }
+            return n;
+        } finally {
+            endWrite();
+        }
+    }
+
+    @Override
+    public long size() throws IOException {
+        beginRead();
+        try {
+            ensureOpen();
+            return last;
+        } finally {
+            endRead();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed)
+            return;
+        beginWrite();
+        try {
+            closed = true;
+            buf = null;
+            pos = 0;
+            last = 0;
+        } finally {
+            endWrite();
+        }
+    }
+
+    /**
+     * Creates a newly allocated byte array. Its size is the current
+     * size of this channel and the valid contents of the buffer
+     * have been copied into it.
+     *
+     * @return the current contents of this channel, as a byte array.
+     */
+    public byte[] toByteArray() {
+        beginRead();
+        try {
+            // avoid copy if last == bytes.length?
+            return Arrays.copyOf(buf, last);
+        } finally {
+            endRead();
+        }
+    }
+
+    private void ensureOpen() throws IOException {
+        if (closed)
+            throw new ClosedChannelException();
+    }
+
+    final void beginWrite() {
+        rwlock.writeLock().lock();
+    }
+
+    final void endWrite() {
+        rwlock.writeLock().unlock();
+    }
+
+    private final void beginRead() {
+        rwlock.readLock().lock();
+    }
+
+    private final void endRead() {
+        rwlock.readLock().unlock();
+    }
+
+    private void ensureCapacity(int minCapacity) {
+        // overflow-conscious code
+        if (minCapacity - buf.length > 0) {
+            grow(minCapacity);
+        }
+    }
+
+    /**
+     * The maximum size of array to allocate.
+     * Some VMs reserve some header words in an array.
+     * Attempts to allocate larger arrays may result in
+     * OutOfMemoryError: Requested array size exceeds VM limit
+     */
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    /**
+     * Increases the capacity to ensure that it can hold at least the
+     * number of elements specified by the minimum capacity argument.
+     *
+     * @param minCapacity the desired minimum capacity
+     */
+    private void grow(int minCapacity) {
+        // overflow-conscious code
+        int oldCapacity = buf.length;
+        int newCapacity = oldCapacity << 1;
+        if (newCapacity - minCapacity < 0)
+            newCapacity = minCapacity;
+        if (newCapacity - MAX_ARRAY_SIZE > 0)
+            newCapacity = hugeCapacity(minCapacity);
+        buf = Arrays.copyOf(buf, newCapacity);
+    }
+
+    private static int hugeCapacity(int minCapacity) {
+        if (minCapacity < 0) // overflow
+            throw new OutOfMemoryError("Required length exceeds implementation limit");
+        return (minCapacity > MAX_ARRAY_SIZE) ? Integer.MAX_VALUE : MAX_ARRAY_SIZE;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipCoder.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipCoder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.util.Arrays;
+
+/**
+ * Utility class for zipfile name and comment decoding and encoding
+ *
+ * @author Xueming Shen
+ */
+class ZipCoder {
+
+    static class UTF8 extends ZipCoder {
+        UTF8() {
+            super(UTF_8);
+        }
+
+        @Override
+        byte[] getBytes(String s) { // fast pass for ascii
+            for (int i = 0; i < s.length(); i++) {
+                if (s.charAt(i) > 0x7f)
+                    return super.getBytes(s);
+            }
+            return s.getBytes(ISO_8859_1);
+        }
+
+        @Override
+        String toString(byte[] ba) {
+            for (byte b : ba) {
+                if (b < 0)
+                    return super.toString(ba);
+            }
+            return new String(ba, ISO_8859_1);
+        }
+    }
+
+    private static final ZipCoder utf8 = new UTF8();
+
+    public static ZipCoder get(String csn) {
+        Charset cs = Charset.forName(csn);
+        if (cs.name().equals("UTF-8")) {
+            return utf8;
+        }
+        return new ZipCoder(cs);
+    }
+
+    String toString(byte[] ba) {
+        CharsetDecoder cd = decoder().reset();
+        int clen = (int) (ba.length * cd.maxCharsPerByte());
+        char[] ca = new char[clen];
+        if (clen == 0)
+            return new String(ca);
+        ByteBuffer bb = ByteBuffer.wrap(ba, 0, ba.length);
+        CharBuffer cb = CharBuffer.wrap(ca);
+        CoderResult cr = cd.decode(bb, cb, true);
+        if (!cr.isUnderflow())
+            throw new IllegalArgumentException(cr.toString());
+        cr = cd.flush(cb);
+        if (!cr.isUnderflow())
+            throw new IllegalArgumentException(cr.toString());
+        return new String(ca, 0, cb.position());
+    }
+
+    byte[] getBytes(String s) {
+        CharsetEncoder ce = encoder().reset();
+        char[] ca = s.toCharArray();
+        int len = (int) (ca.length * ce.maxBytesPerChar());
+        byte[] ba = new byte[len];
+        if (len == 0)
+            return ba;
+        ByteBuffer bb = ByteBuffer.wrap(ba);
+        CharBuffer cb = CharBuffer.wrap(ca);
+        CoderResult cr = ce.encode(cb, bb, true);
+        if (!cr.isUnderflow())
+            throw new IllegalArgumentException(cr.toString());
+        cr = ce.flush(bb);
+        if (!cr.isUnderflow())
+            throw new IllegalArgumentException(cr.toString());
+        if (bb.position() == ba.length) // defensive copy?
+            return ba;
+        else
+            return Arrays.copyOf(ba, bb.position());
+    }
+
+    boolean isUTF8() {
+        return cs == UTF_8;
+    }
+
+    private Charset cs;
+
+    private ZipCoder(Charset cs) {
+        this.cs = cs;
+    }
+
+    private final ThreadLocal<CharsetDecoder> decTL = new ThreadLocal<>();
+    private final ThreadLocal<CharsetEncoder> encTL = new ThreadLocal<>();
+
+    private CharsetDecoder decoder() {
+        CharsetDecoder dec = decTL.get();
+        if (dec == null) {
+            dec = cs.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT);
+            decTL.set(dec);
+        }
+        return dec;
+    }
+
+    private CharsetEncoder encoder() {
+        CharsetEncoder enc = encTL.get();
+        if (enc == null) {
+            enc = cs.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT);
+            encTL.set(enc);
+        }
+        return enc;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipConstants.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipConstants.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+/**
+ * @author Xueming Shen
+ */
+class ZipConstants {
+    /*
+     * Compression methods
+     */
+    static final int METHOD_STORED = 0;
+    static final int METHOD_DEFLATED = 8;
+    static final int METHOD_DEFLATED64 = 9;
+    static final int METHOD_BZIP2 = 12;
+    static final int METHOD_LZMA = 14;
+    static final int METHOD_LZ77 = 19;
+    static final int METHOD_AES = 99;
+
+    /*
+     * General purpose bit flag
+     */
+    static final int FLAG_ENCRYPTED = 0x01;
+    static final int FLAG_DATADESCR = 0x08; // crc, size and csize in dd
+    static final int FLAG_USE_UTF8 = 0x800; // If this bit is set the filename and
+                                            // comment fields for this file must be
+                                            // encoded using UTF-8.
+                                            /*
+                                             * Header signatures
+                                             */
+    static long LOCSIG = 0x04034b50L; // "PK\003\004"
+    static long EXTSIG = 0x08074b50L; // "PK\007\008"
+    static long CENSIG = 0x02014b50L; // "PK\001\002"
+    static long ENDSIG = 0x06054b50L; // "PK\005\006"
+
+    /*
+     * Header sizes in bytes (including signatures)
+     */
+    static final int LOCHDR = 30; // LOC header size
+    static final int EXTHDR = 16; // EXT header size
+    static final int CENHDR = 46; // CEN header size
+    static final int ENDHDR = 22; // END header size
+
+    /*
+     * File attribute compatibility types of CEN field "version made by"
+     */
+    static final int FILE_ATTRIBUTES_UNIX = 3; // Unix
+
+    /*
+     * Base values for CEN field "version made by"
+     */
+    static final int VERSION_MADE_BY_BASE_UNIX = FILE_ATTRIBUTES_UNIX << 8; // Unix
+
+    /*
+     * Local file (LOC) header field offsets
+     */
+    static final int LOCVER = 4; // version needed to extract
+    static final int LOCFLG = 6; // general purpose bit flag
+    static final int LOCHOW = 8; // compression method
+    static final int LOCTIM = 10; // modification time
+    static final int LOCCRC = 14; // uncompressed file crc-32 value
+    static final int LOCSIZ = 18; // compressed size
+    static final int LOCLEN = 22; // uncompressed size
+    static final int LOCNAM = 26; // filename length
+    static final int LOCEXT = 28; // extra field length
+
+    /*
+     * Extra local (EXT) header field offsets
+     */
+    static final int EXTCRC = 4; // uncompressed file crc-32 value
+    static final int EXTSIZ = 8; // compressed size
+    static final int EXTLEN = 12; // uncompressed size
+
+    /*
+     * Central directory (CEN) header field offsets
+     */
+    static final int CENVEM = 4; // version made by
+    static final int CENVER = 6; // version needed to extract
+    static final int CENFLG = 8; // encrypt, decrypt flags
+    static final int CENHOW = 10; // compression method
+    static final int CENTIM = 12; // modification time
+    static final int CENCRC = 16; // uncompressed file crc-32 value
+    static final int CENSIZ = 20; // compressed size
+    static final int CENLEN = 24; // uncompressed size
+    static final int CENNAM = 28; // filename length
+    static final int CENEXT = 30; // extra field length
+    static final int CENCOM = 32; // comment length
+    static final int CENDSK = 34; // disk number start
+    static final int CENATT = 36; // internal file attributes
+    static final int CENATX = 38; // external file attributes
+    static final int CENOFF = 42; // LOC header offset
+
+    /*
+     * End of central directory (END) header field offsets
+     */
+    static final int ENDSUB = 8; // number of entries on this disk
+    static final int ENDTOT = 10; // total number of entries
+    static final int ENDSIZ = 12; // central directory size in bytes
+    static final int ENDOFF = 16; // offset of first CEN header
+    static final int ENDCOM = 20; // zip file comment length
+
+    /*
+     * ZIP64 constants
+     */
+    static final long ZIP64_ENDSIG = 0x06064b50L; // "PK\006\006"
+    static final long ZIP64_LOCSIG = 0x07064b50L; // "PK\006\007"
+    static final int ZIP64_ENDHDR = 56; // ZIP64 end header size
+    static final int ZIP64_LOCHDR = 20; // ZIP64 end loc header size
+    static final int ZIP64_EXTHDR = 24; // EXT header size
+    static final int ZIP64_EXTID = 0x0001; // Extra field Zip64 header ID
+
+    static final int ZIP64_MINVAL32 = 0xFFFF;
+    static final long ZIP64_MINVAL = 0xFFFFFFFFL;
+
+    /*
+     * Zip64 End of central directory (END) header field offsets
+     */
+    static final int ZIP64_ENDLEN = 4; // size of zip64 end of central dir
+    static final int ZIP64_ENDVEM = 12; // version made by
+    static final int ZIP64_ENDVER = 14; // version needed to extract
+    static final int ZIP64_ENDNMD = 16; // number of this disk
+    static final int ZIP64_ENDDSK = 20; // disk number of start
+    static final int ZIP64_ENDTOD = 24; // total number of entries on this disk
+    static final int ZIP64_ENDTOT = 32; // total number of entries
+    static final int ZIP64_ENDSIZ = 40; // central directory size in bytes
+    static final int ZIP64_ENDOFF = 48; // offset of first CEN header
+    static final int ZIP64_ENDEXT = 56; // zip64 extensible data sector
+
+    /*
+     * Zip64 End of central directory locator field offsets
+     */
+    static final int ZIP64_LOCDSK = 4; // disk number start
+    static final int ZIP64_LOCOFF = 8; // offset of zip64 end
+    static final int ZIP64_LOCTOT = 16; // total number of disks
+
+    /*
+     * Zip64 Extra local (EXT) header field offsets
+     */
+    static final int ZIP64_EXTCRC = 4; // uncompressed file crc-32 value
+    static final int ZIP64_EXTSIZ = 8; // compressed size, 8-byte
+    static final int ZIP64_EXTLEN = 16; // uncompressed size, 8-byte
+
+    /*
+     * Extra field header ID
+     */
+    static final int EXTID_ZIP64 = 0x0001; // ZIP64
+    static final int EXTID_NTFS = 0x000a; // NTFS
+    static final int EXTID_UNIX = 0x000d; // UNIX
+    static final int EXTID_EFS = 0x0017; // Strong Encryption
+    static final int EXTID_EXTT = 0x5455; // Info-ZIP Extended Timestamp
+
+    /*
+     * fields access methods
+     */
+    ///////////////////////////////////////////////////////
+    static final int CH(byte[] b, int n) {
+        return Byte.toUnsignedInt(b[n]);
+    }
+
+    static final int SH(byte[] b, int n) {
+        return Byte.toUnsignedInt(b[n]) | (Byte.toUnsignedInt(b[n + 1]) << 8);
+    }
+
+    static final long LG(byte[] b, int n) {
+        return ((SH(b, n)) | (SH(b, n + 2) << 16)) & 0xffffffffL;
+    }
+
+    static final long LL(byte[] b, int n) {
+        return (LG(b, n)) | (LG(b, n + 4) << 32);
+    }
+
+    static long getSig(byte[] b, int n) {
+        return LG(b, n);
+    }
+
+    private static boolean pkSigAt(byte[] b, int n, int b1, int b2) {
+        return b[n] == 'P' & b[n + 1] == 'K' & b[n + 2] == b1 & b[n + 3] == b2;
+    }
+
+    static boolean cenSigAt(byte[] b, int n) {
+        return pkSigAt(b, n, 1, 2);
+    }
+
+    static boolean locSigAt(byte[] b, int n) {
+        return pkSigAt(b, n, 3, 4);
+    }
+
+    static boolean endSigAt(byte[] b, int n) {
+        return pkSigAt(b, n, 5, 6);
+    }
+
+    static boolean extSigAt(byte[] b, int n) {
+        return pkSigAt(b, n, 7, 8);
+    }
+
+    static boolean end64SigAt(byte[] b, int n) {
+        return pkSigAt(b, n, 6, 6);
+    }
+
+    static boolean locator64SigAt(byte[] b, int n) {
+        return pkSigAt(b, n, 6, 7);
+    }
+
+    // local file (LOC) header fields
+    static final long LOCSIG(byte[] b) {
+        return LG(b, 0);
+    } // signature
+
+    static final int LOCVER(byte[] b) {
+        return SH(b, 4);
+    } // version needed to extract
+
+    static final int LOCFLG(byte[] b) {
+        return SH(b, 6);
+    } // general purpose bit flags
+
+    static final int LOCHOW(byte[] b) {
+        return SH(b, 8);
+    } // compression method
+
+    static final long LOCTIM(byte[] b) {
+        return LG(b, 10);
+    } // modification time
+
+    static final long LOCCRC(byte[] b) {
+        return LG(b, 14);
+    } // crc of uncompressed data
+
+    static final long LOCSIZ(byte[] b) {
+        return LG(b, 18);
+    } // compressed data size
+
+    static final long LOCLEN(byte[] b) {
+        return LG(b, 22);
+    } // uncompressed data size
+
+    static final int LOCNAM(byte[] b) {
+        return SH(b, 26);
+    } // filename length
+
+    static final int LOCEXT(byte[] b) {
+        return SH(b, 28);
+    } // extra field length
+
+    // extra local (EXT) header fields
+    static final long EXTCRC(byte[] b) {
+        return LG(b, 4);
+    } // crc of uncompressed data
+
+    static final long EXTSIZ(byte[] b) {
+        return LG(b, 8);
+    } // compressed size
+
+    static final long EXTLEN(byte[] b) {
+        return LG(b, 12);
+    } // uncompressed size
+
+    // end of central directory header (END) fields
+    static final int ENDSUB(byte[] b) {
+        return SH(b, 8);
+    } // number of entries on this disk
+
+    static final int ENDTOT(byte[] b) {
+        return SH(b, 10);
+    } // total number of entries
+
+    static final long ENDSIZ(byte[] b) {
+        return LG(b, 12);
+    } // central directory size
+
+    static final long ENDOFF(byte[] b) {
+        return LG(b, 16);
+    } // central directory offset
+
+    static final int ENDCOM(byte[] b) {
+        return SH(b, 20);
+    } // size of zip file comment
+
+    static final int ENDCOM(byte[] b, int off) {
+        return SH(b, off + 20);
+    }
+
+    // zip64 end of central directory recoder fields
+    static final long ZIP64_ENDTOD(byte[] b) {
+        return LL(b, 24);
+    } // total number of entries on disk
+
+    static final long ZIP64_ENDTOT(byte[] b) {
+        return LL(b, 32);
+    } // total number of entries
+
+    static final long ZIP64_ENDSIZ(byte[] b) {
+        return LL(b, 40);
+    } // central directory size
+
+    static final long ZIP64_ENDOFF(byte[] b) {
+        return LL(b, 48);
+    } // central directory offset
+
+    static final long ZIP64_LOCOFF(byte[] b) {
+        return LL(b, 8);
+    } // zip64 end offset
+
+    // central directory header (CEN) fields
+    static final long CENSIG(byte[] b, int pos) {
+        return LG(b, pos + 0);
+    } // signature
+
+    static final int CENVEM(byte[] b, int pos) {
+        return SH(b, pos + 4);
+    } // version made by
+
+    static final int CENVEM_FA(byte[] b, int pos) {
+        return CH(b, pos + 5);
+    } // file attribute compatibility
+
+    static final int CENVER(byte[] b, int pos) {
+        return SH(b, pos + 6);
+    } // version needed to extract
+
+    static final int CENFLG(byte[] b, int pos) {
+        return SH(b, pos + 8);
+    } // encrypt, decrypt flags
+
+    static final int CENHOW(byte[] b, int pos) {
+        return SH(b, pos + 10);
+    } // compression method
+
+    static final long CENTIM(byte[] b, int pos) {
+        return LG(b, pos + 12);
+    } // modification time
+
+    static final long CENCRC(byte[] b, int pos) {
+        return LG(b, pos + 16);
+    } // uncompressed file crc-32 value
+
+    static final long CENSIZ(byte[] b, int pos) {
+        return LG(b, pos + 20);
+    } // compressed size
+
+    static final long CENLEN(byte[] b, int pos) {
+        return LG(b, pos + 24);
+    } // uncompressed size
+
+    static final int CENNAM(byte[] b, int pos) {
+        return SH(b, pos + 28);
+    } // filename length
+
+    static final int CENEXT(byte[] b, int pos) {
+        return SH(b, pos + 30);
+    } // extra field length
+
+    static final int CENCOM(byte[] b, int pos) {
+        return SH(b, pos + 32);
+    } // comment length
+
+    static final int CENDSK(byte[] b, int pos) {
+        return SH(b, pos + 34);
+    } // disk number start
+
+    static final int CENATT(byte[] b, int pos) {
+        return SH(b, pos + 36);
+    } // internal file attributes
+
+    static final long CENATX(byte[] b, int pos) {
+        return LG(b, pos + 38);
+    } // external file attributes
+
+    static final int CENATX_PERMS(byte[] b, int pos) {
+        return SH(b, pos + 40);
+    } // posix permission data
+
+    static final long CENOFF(byte[] b, int pos) {
+        return LG(b, pos + 42);
+    } // LOC header offset
+
+    /* The END header is followed by a variable length comment of size < 64k. */
+    static final long END_MAXLEN = 0xFFFF + ENDHDR;
+    static final int READBLOCKSZ = 128;
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipDirectoryStream.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipDirectoryStream.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.nio.file.ClosedDirectoryStreamException;
+import java.nio.file.DirectoryIteratorException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ *
+ * @author Xueming Shen, Rajendra Gutupalli, Jaya Hangal
+ */
+class ZipDirectoryStream implements DirectoryStream<Path> {
+
+    private final ZipFileSystem zipfs;
+    private final ZipPath dir;
+    private final Filter<? super Path> filter;
+    private volatile boolean isClosed;
+    private volatile Iterator<Path> itr;
+
+    ZipDirectoryStream(ZipPath dir,
+            Filter<? super Path> filter)
+            throws IOException {
+        this.zipfs = dir.getFileSystem();
+        this.dir = dir;
+        this.filter = filter;
+        // sanity check
+        if (!zipfs.isDirectory(dir.getResolvedPath()))
+            throw new NotDirectoryException(dir.toString());
+    }
+
+    @Override
+    public synchronized Iterator<Path> iterator() {
+        if (isClosed)
+            throw new ClosedDirectoryStreamException();
+        if (itr != null)
+            throw new IllegalStateException("Iterator has already been returned");
+
+        try {
+            itr = zipfs.iteratorOf(dir, filter);
+        } catch (IOException e) {
+            throw new DirectoryIteratorException(e);
+        }
+
+        return new Iterator<Path>() {
+            @Override
+            public boolean hasNext() {
+                if (isClosed)
+                    return false;
+                return itr.hasNext();
+            }
+
+            @Override
+            public synchronized Path next() {
+                if (isClosed)
+                    throw new NoSuchElementException();
+                return itr.next();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        isClosed = true;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipFileAttributeView.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipFileAttributeView.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Xueming Shen, Rajendra Gutupalli, Jaya Hangal
+ */
+class ZipFileAttributeView implements BasicFileAttributeView {
+    static enum AttrID {
+        size,
+        creationTime,
+        lastAccessTime,
+        lastModifiedTime,
+        isDirectory,
+        isRegularFile,
+        isSymbolicLink,
+        isOther,
+        fileKey,
+        compressedSize,
+        crc,
+        method,
+        owner,
+        group,
+        permissions
+    }
+
+    final ZipPath path;
+    private final boolean isZipView;
+
+    ZipFileAttributeView(ZipPath path, boolean isZipView) {
+        this.path = path;
+        this.isZipView = isZipView;
+    }
+
+    @Override
+    public String name() {
+        return isZipView ? "zip" : "basic";
+    }
+
+    @Override
+    public BasicFileAttributes readAttributes() throws IOException {
+        return path.readAttributes();
+    }
+
+    @Override
+    public void setTimes(FileTime lastModifiedTime,
+            FileTime lastAccessTime,
+            FileTime createTime)
+            throws IOException {
+        path.setTimes(lastModifiedTime, lastAccessTime, createTime);
+    }
+
+    public void setPermissions(Set<PosixFilePermission> perms) throws IOException {
+        path.setPermissions(perms);
+    }
+
+    @SuppressWarnings("unchecked")
+    void setAttribute(String attribute, Object value)
+            throws IOException {
+        try {
+            if (AttrID.valueOf(attribute) == AttrID.lastModifiedTime)
+                setTimes((FileTime) value, null, null);
+            if (AttrID.valueOf(attribute) == AttrID.lastAccessTime)
+                setTimes(null, (FileTime) value, null);
+            if (AttrID.valueOf(attribute) == AttrID.creationTime)
+                setTimes(null, null, (FileTime) value);
+            if (AttrID.valueOf(attribute) == AttrID.permissions)
+                setPermissions((Set<PosixFilePermission>) value);
+        } catch (IllegalArgumentException x) {
+            throw new UnsupportedOperationException("'" + attribute +
+                    "' is unknown or read-only attribute");
+        }
+    }
+
+    Map<String, Object> readAttributes(String attributes)
+            throws IOException {
+        ZipFileAttributes zfas = (ZipFileAttributes) readAttributes();
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        if ("*".equals(attributes)) {
+            for (AttrID id : AttrID.values()) {
+                try {
+                    map.put(id.name(), attribute(id, zfas));
+                } catch (IllegalArgumentException x) {
+                }
+            }
+        } else {
+            String[] as = attributes.split(",");
+            for (String a : as) {
+                try {
+                    map.put(a, attribute(AttrID.valueOf(a), zfas));
+                } catch (IllegalArgumentException x) {
+                }
+            }
+        }
+        return map;
+    }
+
+    Object attribute(AttrID id, ZipFileAttributes zfas) {
+        switch (id) {
+            case size:
+                return zfas.size();
+            case creationTime:
+                return zfas.creationTime();
+            case lastAccessTime:
+                return zfas.lastAccessTime();
+            case lastModifiedTime:
+                return zfas.lastModifiedTime();
+            case isDirectory:
+                return zfas.isDirectory();
+            case isRegularFile:
+                return zfas.isRegularFile();
+            case isSymbolicLink:
+                return zfas.isSymbolicLink();
+            case isOther:
+                return zfas.isOther();
+            case fileKey:
+                return zfas.fileKey();
+            case compressedSize:
+                if (isZipView)
+                    return zfas.compressedSize();
+                break;
+            case crc:
+                if (isZipView)
+                    return zfas.crc();
+                break;
+            case method:
+                if (isZipView)
+                    return zfas.method();
+                break;
+            case permissions:
+                if (isZipView) {
+                    return zfas.storedPermissions().orElse(null);
+                }
+                break;
+            default:
+                break;
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipFileAttributes.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipFileAttributes.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The attributes of a file stored in a zip file.
+ *
+ * @author Xueming Shen, Rajendra Gutupalli, Jaya Hangal
+ */
+interface ZipFileAttributes extends BasicFileAttributes {
+    long compressedSize();
+
+    long crc();
+
+    int method();
+
+    byte[] extra();
+
+    byte[] comment();
+
+    Optional<Set<PosixFilePermission>> storedPermissions();
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipFileStore.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipFileStore.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileOwnerAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+import java.nio.file.attribute.PosixFileAttributeView;
+
+/**
+ * @author Xueming Shen, Rajendra Gutupalli, Jaya Hangal
+ */
+class ZipFileStore extends FileStore {
+
+    private final ZipFileSystem zfs;
+
+    ZipFileStore(ZipPath zpath) {
+        this.zfs = zpath.getFileSystem();
+    }
+
+    @Override
+    public String name() {
+        return zfs.toString() + "/";
+    }
+
+    @Override
+    public String type() {
+        return "zipfs";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return zfs.isReadOnly();
+    }
+
+    @Override
+    public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+        return (type == BasicFileAttributeView.class ||
+                type == ZipFileAttributeView.class ||
+                ((type == FileOwnerAttributeView.class ||
+                        type == PosixFileAttributeView.class) && zfs.supportPosix));
+    }
+
+    @Override
+    public boolean supportsFileAttributeView(String name) {
+        return "basic".equals(name) || "zip".equals(name) ||
+                (("owner".equals(name) || "posix".equals(name)) && zfs.supportPosix);
+    }
+
+    @Override
+    public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
+        if (type == null)
+            throw new NullPointerException();
+        return null;
+    }
+
+    @Override
+    public long getTotalSpace() throws IOException {
+        return new ZipFileStoreAttributes(this).totalSpace();
+    }
+
+    @Override
+    public long getUsableSpace() throws IOException {
+        return new ZipFileStoreAttributes(this).usableSpace();
+    }
+
+    @Override
+    public long getUnallocatedSpace() throws IOException {
+        return new ZipFileStoreAttributes(this).unallocatedSpace();
+    }
+
+    @Override
+    public Object getAttribute(String attribute) throws IOException {
+        if (attribute.equals("totalSpace"))
+            return getTotalSpace();
+        if (attribute.equals("usableSpace"))
+            return getUsableSpace();
+        if (attribute.equals("unallocatedSpace"))
+            return getUnallocatedSpace();
+        throw new UnsupportedOperationException("does not support the given attribute");
+    }
+
+    private static class ZipFileStoreAttributes {
+        final FileStore fstore;
+        final long size;
+
+        ZipFileStoreAttributes(ZipFileStore fileStore)
+                throws IOException {
+            Path path = FileSystems.getDefault().getPath(fileStore.name());
+            this.size = Files.size(path);
+            this.fstore = Files.getFileStore(path);
+        }
+
+        long totalSpace() {
+            return size;
+        }
+
+        long usableSpace() throws IOException {
+            if (!fstore.isReadOnly())
+                return fstore.getUsableSpace();
+            return 0;
+        }
+
+        long unallocatedSpace() throws IOException {
+            if (!fstore.isReadOnly())
+                return fstore.getUnallocatedSpace();
+            return 0;
+        }
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipFileSystem.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipFileSystem.java
@@ -264,7 +264,8 @@ class ZipFileSystem extends FileSystem {
         // sm and existence check
         zfpath.getFileSystem().provider().checkAccess(zfpath, AccessMode.READ);
         @SuppressWarnings("removal")
-        boolean writeable = AccessController.doPrivileged(
+        // QUARKUS: make writeable check configurable using env
+        boolean writeable = isTrue(env, "writeable") && AccessController.doPrivileged(
                 (PrivilegedAction<Boolean>) () -> Files.isWritable(zfpath));
         this.readOnly = !writeable;
         this.zc = ZipCoder.get(nameEncoding);

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipFileSystem.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipFileSystem.java
@@ -1,0 +1,3327 @@
+/*
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENATX_PERMS;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENCOM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENCRC;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENEXT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENFLG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENHOW;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENLEN;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENNAM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENOFF;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENSIZ;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENTIM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENVEM_FA;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENVER;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CH;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ENDCOM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ENDHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ENDOFF;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ENDSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ENDSIZ;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ENDTOT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.END_MAXLEN;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTID_EXTT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTID_NTFS;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTID_ZIP64;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.FILE_ATTRIBUTES_UNIX;
+import static io.quarkus.fs.util.zipfs.ZipConstants.FLAG_DATADESCR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.FLAG_USE_UTF8;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LL;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCEXT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCNAM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.METHOD_DEFLATED;
+import static io.quarkus.fs.util.zipfs.ZipConstants.METHOD_STORED;
+import static io.quarkus.fs.util.zipfs.ZipConstants.READBLOCKSZ;
+import static io.quarkus.fs.util.zipfs.ZipConstants.SH;
+import static io.quarkus.fs.util.zipfs.ZipConstants.VERSION_MADE_BY_BASE_UNIX;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_ENDHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_ENDOFF;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_ENDSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_ENDSIZ;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_ENDTOT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_LOCHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_LOCOFF;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_LOCSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_MINVAL;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_MINVAL32;
+import static io.quarkus.fs.util.zipfs.ZipConstants.cenSigAt;
+import static io.quarkus.fs.util.zipfs.ZipConstants.end64SigAt;
+import static io.quarkus.fs.util.zipfs.ZipConstants.getSig;
+import static io.quarkus.fs.util.zipfs.ZipConstants.locSigAt;
+import static io.quarkus.fs.util.zipfs.ZipConstants.locator64SigAt;
+import static io.quarkus.fs.util.zipfs.ZipUtils.dosToJavaTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.javaToDosTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.javaToUnixTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.javaToWinTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.toDirectoryPath;
+import static io.quarkus.fs.util.zipfs.ZipUtils.toRegexPattern;
+import static io.quarkus.fs.util.zipfs.ZipUtils.unixToJavaTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.winToJavaTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.writeBytes;
+import static io.quarkus.fs.util.zipfs.ZipUtils.writeInt;
+import static io.quarkus.fs.util.zipfs.ZipUtils.writeLong;
+import static io.quarkus.fs.util.zipfs.ZipUtils.writeShort;
+import static java.lang.Boolean.TRUE;
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.Runtime.Version;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.ClosedFileSystemException;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.ReadOnlyFileSystemException;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+import java.util.zip.ZipException;
+
+/**
+ * A FileSystem built on a zip file
+ *
+ * @author Xueming Shen
+ */
+class ZipFileSystem extends FileSystem {
+    // statics
+    @SuppressWarnings("removal")
+    private static final boolean isWindows = AccessController.doPrivileged(
+            (PrivilegedAction<Boolean>) () -> System.getProperty("os.name")
+                    .startsWith("Windows"));
+    private static final byte[] ROOTPATH = new byte[] { '/' };
+    private static final String PROPERTY_POSIX = "enablePosixFileAttributes";
+    private static final String PROPERTY_DEFAULT_OWNER = "defaultOwner";
+    private static final String PROPERTY_DEFAULT_GROUP = "defaultGroup";
+    private static final String PROPERTY_DEFAULT_PERMISSIONS = "defaultPermissions";
+    // Property used to specify the entry version to use for a multi-release JAR
+    private static final String PROPERTY_RELEASE_VERSION = "releaseVersion";
+    // Original property used to specify the entry version to use for a
+    // multi-release JAR which is kept for backwards compatibility.
+    private static final String PROPERTY_MULTI_RELEASE = "multi-release";
+
+    private static final Set<PosixFilePermission> DEFAULT_PERMISSIONS = PosixFilePermissions.fromString("rwxrwxrwx");
+    // Property used to specify the compression mode to use
+    private static final String PROPERTY_COMPRESSION_METHOD = "compressionMethod";
+    // Value specified for compressionMethod property to compress Zip entries
+    private static final String COMPRESSION_METHOD_DEFLATED = "DEFLATED";
+    // Value specified for compressionMethod property to not compress Zip entries
+    private static final String COMPRESSION_METHOD_STORED = "STORED";
+
+    private final ZipFileSystemProvider provider;
+    private final Path zfpath;
+    final ZipCoder zc;
+    private final ZipPath rootdir;
+    private boolean readOnly; // readonly file system, false by default
+
+    // default time stamp for pseudo entries
+    private final long zfsDefaultTimeStamp = System.currentTimeMillis();
+
+    // configurable by env map
+    private final boolean noExtt; // see readExtra()
+    private final boolean useTempFile; // use a temp file for newOS, default
+                                       // is to use BAOS for better performance
+    private final boolean forceEnd64;
+    private final int defaultCompressionMethod; // METHOD_STORED if "noCompression=true"
+                                                // METHOD_DEFLATED otherwise
+
+    // entryLookup is identity by default, will be overridden for multi-release jars
+    private Function<byte[], byte[]> entryLookup = Function.identity();
+
+    // POSIX support
+    final boolean supportPosix;
+    private final UserPrincipal defaultOwner;
+    private final GroupPrincipal defaultGroup;
+    private final Set<PosixFilePermission> defaultPermissions;
+
+    private final Set<String> supportedFileAttributeViews;
+
+    ZipFileSystem(ZipFileSystemProvider provider,
+            Path zfpath,
+            Map<String, ?> env) throws IOException {
+        // default encoding for name/comment
+        String nameEncoding = env.containsKey("encoding") ? (String) env.get("encoding") : "UTF-8";
+        this.noExtt = "false".equals(env.get("zipinfo-time"));
+        this.useTempFile = isTrue(env, "useTempFile");
+        this.forceEnd64 = isTrue(env, "forceZIP64End");
+        this.defaultCompressionMethod = getDefaultCompressionMethod(env);
+        this.supportPosix = isTrue(env, PROPERTY_POSIX);
+        this.defaultOwner = initOwner(zfpath, env);
+        this.defaultGroup = initGroup(zfpath, env);
+        this.defaultPermissions = initPermissions(env);
+        this.supportedFileAttributeViews = supportPosix ? Set.of("basic", "posix", "zip") : Set.of("basic", "zip");
+        if (Files.notExists(zfpath)) {
+            // create a new zip if it doesn't exist
+            if (isTrue(env, "create")) {
+                try (OutputStream os = Files.newOutputStream(zfpath, CREATE_NEW, WRITE)) {
+                    new END().write(os, 0, forceEnd64);
+                }
+            } else {
+                throw new NoSuchFileException(zfpath.toString());
+            }
+        }
+        // sm and existence check
+        zfpath.getFileSystem().provider().checkAccess(zfpath, AccessMode.READ);
+        @SuppressWarnings("removal")
+        boolean writeable = AccessController.doPrivileged(
+                (PrivilegedAction<Boolean>) () -> Files.isWritable(zfpath));
+        this.readOnly = !writeable;
+        this.zc = ZipCoder.get(nameEncoding);
+        this.rootdir = new ZipPath(this, new byte[] { '/' });
+        this.ch = Files.newByteChannel(zfpath, READ);
+        try {
+            this.cen = initCEN();
+        } catch (IOException x) {
+            try {
+                this.ch.close();
+            } catch (IOException xx) {
+                x.addSuppressed(xx);
+            }
+            throw x;
+        }
+        this.provider = provider;
+        this.zfpath = zfpath;
+
+        initializeReleaseVersion(env);
+    }
+
+    /**
+     * Return the compression method to use (STORED or DEFLATED). If the
+     * property {@code commpressionMethod} is set use its value to determine
+     * the compression method to use. If the property is not set, then the
+     * default compression is DEFLATED unless the property {@code noCompression}
+     * is set which is supported for backwards compatibility.
+     * 
+     * @param env Zip FS map of properties
+     * @return The Compression method to use
+     */
+    private int getDefaultCompressionMethod(Map<String, ?> env) {
+        int result = isTrue(env, "noCompression") ? METHOD_STORED : METHOD_DEFLATED;
+        if (env.containsKey(PROPERTY_COMPRESSION_METHOD)) {
+            Object compressionMethod = env.get(PROPERTY_COMPRESSION_METHOD);
+            if (compressionMethod != null) {
+                if (compressionMethod instanceof String) {
+                    switch (((String) compressionMethod).toUpperCase()) {
+                        case COMPRESSION_METHOD_STORED:
+                            result = METHOD_STORED;
+                            break;
+                        case COMPRESSION_METHOD_DEFLATED:
+                            result = METHOD_DEFLATED;
+                            break;
+                        default:
+                            throw new IllegalArgumentException(String.format(
+                                    "The value for the %s property must be %s or %s",
+                                    PROPERTY_COMPRESSION_METHOD, COMPRESSION_METHOD_STORED,
+                                    COMPRESSION_METHOD_DEFLATED));
+                    }
+                } else {
+                    throw new IllegalArgumentException(String.format(
+                            "The Object type for the %s property must be a String",
+                            PROPERTY_COMPRESSION_METHOD));
+                }
+            } else {
+                throw new IllegalArgumentException(String.format(
+                        "The value for the %s property must be %s or %s",
+                        PROPERTY_COMPRESSION_METHOD, COMPRESSION_METHOD_STORED,
+                        COMPRESSION_METHOD_DEFLATED));
+            }
+        }
+        return result;
+    }
+
+    // returns true if there is a name=true/"true" setting in env
+    private static boolean isTrue(Map<String, ?> env, String name) {
+        return "true".equals(env.get(name)) || TRUE.equals(env.get(name));
+    }
+
+    // Initialize the default owner for files inside the zip archive.
+    // If not specified in env, it is the owner of the archive. If no owner can
+    // be determined, we try to go with system property "user.name". If that's not
+    // accessible, we return "<zipfs_default>".
+    @SuppressWarnings("removal")
+    private UserPrincipal initOwner(Path zfpath, Map<String, ?> env) throws IOException {
+        Object o = env.get(PROPERTY_DEFAULT_OWNER);
+        if (o == null) {
+            try {
+                PrivilegedExceptionAction<UserPrincipal> pa = () -> Files.getOwner(zfpath);
+                return AccessController.doPrivileged(pa);
+            } catch (UnsupportedOperationException | PrivilegedActionException e) {
+                if (e instanceof UnsupportedOperationException ||
+                        e.getCause() instanceof NoSuchFileException) {
+                    PrivilegedAction<String> pa = () -> System.getProperty("user.name");
+                    String userName = AccessController.doPrivileged(pa);
+                    return () -> userName;
+                } else {
+                    throw new IOException(e);
+                }
+            }
+        }
+        if (o instanceof String) {
+            if (((String) o).isEmpty()) {
+                throw new IllegalArgumentException("Value for property " +
+                        PROPERTY_DEFAULT_OWNER + " must not be empty.");
+            }
+            return () -> (String) o;
+        }
+        if (o instanceof UserPrincipal) {
+            return (UserPrincipal) o;
+        }
+        throw new IllegalArgumentException("Value for property " +
+                PROPERTY_DEFAULT_OWNER + " must be of type " + String.class +
+                " or " + UserPrincipal.class);
+    }
+
+    // Initialize the default group for files inside the zip archive.
+    // If not specified in env, we try to determine the group of the zip archive itself.
+    // If this is not possible/unsupported, we will return a group principal going by
+    // the same name as the default owner.
+    @SuppressWarnings("removal")
+    private GroupPrincipal initGroup(Path zfpath, Map<String, ?> env) throws IOException {
+        Object o = env.get(PROPERTY_DEFAULT_GROUP);
+        if (o == null) {
+            try {
+                PosixFileAttributeView zfpv = Files.getFileAttributeView(zfpath, PosixFileAttributeView.class);
+                if (zfpv == null) {
+                    return defaultOwner::getName;
+                }
+                PrivilegedExceptionAction<GroupPrincipal> pa = () -> zfpv.readAttributes().group();
+                return AccessController.doPrivileged(pa);
+            } catch (UnsupportedOperationException | PrivilegedActionException e) {
+                if (e instanceof UnsupportedOperationException ||
+                        e.getCause() instanceof NoSuchFileException) {
+                    return defaultOwner::getName;
+                } else {
+                    throw new IOException(e);
+                }
+            }
+        }
+        if (o instanceof String) {
+            if (((String) o).isEmpty()) {
+                throw new IllegalArgumentException("Value for property " +
+                        PROPERTY_DEFAULT_GROUP + " must not be empty.");
+            }
+            return () -> (String) o;
+        }
+        if (o instanceof GroupPrincipal) {
+            return (GroupPrincipal) o;
+        }
+        throw new IllegalArgumentException("Value for property " +
+                PROPERTY_DEFAULT_GROUP + " must be of type " + String.class +
+                " or " + GroupPrincipal.class);
+    }
+
+    // Initialize the default permissions for files inside the zip archive.
+    // If not specified in env, it will return 777.
+    private Set<PosixFilePermission> initPermissions(Map<String, ?> env) {
+        Object o = env.get(PROPERTY_DEFAULT_PERMISSIONS);
+        if (o == null) {
+            return DEFAULT_PERMISSIONS;
+        }
+        if (o instanceof String) {
+            return PosixFilePermissions.fromString((String) o);
+        }
+        if (!(o instanceof Set)) {
+            throw new IllegalArgumentException("Value for property " +
+                    PROPERTY_DEFAULT_PERMISSIONS + " must be of type " + String.class +
+                    " or " + Set.class);
+        }
+        Set<PosixFilePermission> perms = new HashSet<>();
+        for (Object o2 : (Set<?>) o) {
+            if (o2 instanceof PosixFilePermission) {
+                perms.add((PosixFilePermission) o2);
+            } else {
+                throw new IllegalArgumentException(PROPERTY_DEFAULT_PERMISSIONS +
+                        " must only contain objects of type " + PosixFilePermission.class);
+            }
+        }
+        return perms;
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return provider;
+    }
+
+    @Override
+    public String getSeparator() {
+        return "/";
+    }
+
+    @Override
+    public boolean isOpen() {
+        return isOpen;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    private void checkWritable() {
+        if (readOnly) {
+            throw new ReadOnlyFileSystemException();
+        }
+    }
+
+    void setReadOnly() {
+        this.readOnly = true;
+    }
+
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return List.of(rootdir);
+    }
+
+    ZipPath getRootDir() {
+        return rootdir;
+    }
+
+    @Override
+    public ZipPath getPath(String first, String... more) {
+        if (more.length == 0) {
+            return new ZipPath(this, first);
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(first);
+        for (String path : more) {
+            if (path.length() > 0) {
+                if (sb.length() > 0) {
+                    sb.append('/');
+                }
+                sb.append(path);
+            }
+        }
+        return new ZipPath(this, sb.toString());
+    }
+
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WatchService newWatchService() {
+        throw new UnsupportedOperationException();
+    }
+
+    FileStore getFileStore(ZipPath path) {
+        return new ZipFileStore(path);
+    }
+
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return List.of(new ZipFileStore(rootdir));
+    }
+
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        return supportedFileAttributeViews;
+    }
+
+    @Override
+    public String toString() {
+        return zfpath.toString();
+    }
+
+    Path getZipFile() {
+        return zfpath;
+    }
+
+    private static final String GLOB_SYNTAX = "glob";
+    private static final String REGEX_SYNTAX = "regex";
+
+    @Override
+    public PathMatcher getPathMatcher(String syntaxAndInput) {
+        int pos = syntaxAndInput.indexOf(':');
+        if (pos <= 0 || pos == syntaxAndInput.length()) {
+            throw new IllegalArgumentException();
+        }
+        String syntax = syntaxAndInput.substring(0, pos);
+        String input = syntaxAndInput.substring(pos + 1);
+        String expr;
+        if (syntax.equalsIgnoreCase(GLOB_SYNTAX)) {
+            expr = toRegexPattern(input);
+        } else {
+            if (syntax.equalsIgnoreCase(REGEX_SYNTAX)) {
+                expr = input;
+            } else {
+                throw new UnsupportedOperationException("Syntax '" + syntax +
+                        "' not recognized");
+            }
+        }
+        // return matcher
+        final Pattern pattern = Pattern.compile(expr);
+        return (path) -> pattern.matcher(path.toString()).matches();
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public void close() throws IOException {
+        beginWrite();
+        try {
+            if (!isOpen)
+                return;
+            isOpen = false; // set closed
+        } finally {
+            endWrite();
+        }
+        if (!streams.isEmpty()) { // unlock and close all remaining streams
+            Set<InputStream> copy = new HashSet<>(streams);
+            for (InputStream is : copy)
+                is.close();
+        }
+        beginWrite(); // lock and sync
+        try {
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                sync();
+                return null;
+            });
+            ch.close(); // close the ch just in case no update
+                        // and sync didn't close the ch
+        } catch (PrivilegedActionException e) {
+            throw (IOException) e.getException();
+        } finally {
+            endWrite();
+        }
+
+        synchronized (inflaters) {
+            for (Inflater inf : inflaters)
+                inf.end();
+        }
+        synchronized (deflaters) {
+            for (Deflater def : deflaters)
+                def.end();
+        }
+
+        beginWrite(); // lock and sync
+        try {
+            // Clear the map so that its keys & values can be garbage collected
+            inodes = null;
+        } finally {
+            endWrite();
+        }
+
+        IOException ioe = null;
+        synchronized (tmppaths) {
+            for (Path p : tmppaths) {
+                try {
+                    AccessController.doPrivileged(
+                            (PrivilegedExceptionAction<Boolean>) () -> Files.deleteIfExists(p));
+                } catch (PrivilegedActionException e) {
+                    IOException x = (IOException) e.getException();
+                    if (ioe == null)
+                        ioe = x;
+                    else
+                        ioe.addSuppressed(x);
+                }
+            }
+        }
+        provider.removeFileSystem(zfpath, this);
+        if (ioe != null)
+            throw ioe;
+    }
+
+    ZipFileAttributes getFileAttributes(byte[] path)
+            throws IOException {
+        beginRead();
+        try {
+            ensureOpen();
+            IndexNode inode = getInode(path);
+            if (inode == null) {
+                return null;
+            } else if (inode instanceof Entry) {
+                return (Entry) inode;
+            } else if (inode.pos == -1) {
+                // pseudo directory, uses METHOD_STORED
+                Entry e = supportPosix ? new PosixEntry(inode.name, inode.isdir, METHOD_STORED)
+                        : new Entry(inode.name, inode.isdir, METHOD_STORED);
+                e.mtime = e.atime = e.ctime = zfsDefaultTimeStamp;
+                return e;
+            } else {
+                return supportPosix ? new PosixEntry(this, inode) : new Entry(this, inode);
+            }
+        } finally {
+            endRead();
+        }
+    }
+
+    void checkAccess(byte[] path) throws IOException {
+        beginRead();
+        try {
+            ensureOpen();
+            // is it necessary to readCEN as a sanity check?
+            if (getInode(path) == null) {
+                throw new NoSuchFileException(toString());
+            }
+
+        } finally {
+            endRead();
+        }
+    }
+
+    void setTimes(byte[] path, FileTime mtime, FileTime atime, FileTime ctime)
+            throws IOException {
+        checkWritable();
+        beginWrite();
+        try {
+            ensureOpen();
+            Entry e = getEntry(path); // ensureOpen checked
+            if (e == null)
+                throw new NoSuchFileException(getString(path));
+            if (e.type == Entry.CEN)
+                e.type = Entry.COPY; // copy e
+            if (mtime != null)
+                e.mtime = mtime.toMillis();
+            if (atime != null)
+                e.atime = atime.toMillis();
+            if (ctime != null)
+                e.ctime = ctime.toMillis();
+            update(e);
+        } finally {
+            endWrite();
+        }
+    }
+
+    void setOwner(byte[] path, UserPrincipal owner) throws IOException {
+        checkWritable();
+        beginWrite();
+        try {
+            ensureOpen();
+            Entry e = getEntry(path); // ensureOpen checked
+            if (e == null) {
+                throw new NoSuchFileException(getString(path));
+            }
+            // as the owner information is not persistent, we don't need to
+            // change e.type to Entry.COPY
+            if (e instanceof PosixEntry) {
+                ((PosixEntry) e).owner = owner;
+                update(e);
+            }
+        } finally {
+            endWrite();
+        }
+    }
+
+    void setGroup(byte[] path, GroupPrincipal group) throws IOException {
+        checkWritable();
+        beginWrite();
+        try {
+            ensureOpen();
+            Entry e = getEntry(path); // ensureOpen checked
+            if (e == null) {
+                throw new NoSuchFileException(getString(path));
+            }
+            // as the group information is not persistent, we don't need to
+            // change e.type to Entry.COPY
+            if (e instanceof PosixEntry) {
+                ((PosixEntry) e).group = group;
+                update(e);
+            }
+        } finally {
+            endWrite();
+        }
+    }
+
+    void setPermissions(byte[] path, Set<PosixFilePermission> perms) throws IOException {
+        checkWritable();
+        beginWrite();
+        try {
+            ensureOpen();
+            Entry e = getEntry(path); // ensureOpen checked
+            if (e == null) {
+                throw new NoSuchFileException(getString(path));
+            }
+            if (e.type == Entry.CEN) {
+                e.type = Entry.COPY; // copy e
+            }
+            e.posixPerms = perms == null ? -1 : ZipUtils.permsToFlags(perms);
+            update(e);
+        } finally {
+            endWrite();
+        }
+    }
+
+    boolean exists(byte[] path) {
+        beginRead();
+        try {
+            ensureOpen();
+            return getInode(path) != null;
+        } finally {
+            endRead();
+        }
+    }
+
+    boolean isDirectory(byte[] path) {
+        beginRead();
+        try {
+            IndexNode n = getInode(path);
+            return n != null && n.isDir();
+        } finally {
+            endRead();
+        }
+    }
+
+    // returns the list of child paths of "path"
+    Iterator<Path> iteratorOf(ZipPath dir,
+            DirectoryStream.Filter<? super Path> filter)
+            throws IOException {
+        beginWrite(); // iteration of inodes needs exclusive lock
+        try {
+            ensureOpen();
+            byte[] path = dir.getResolvedPath();
+            IndexNode inode = getInode(path);
+            if (inode == null)
+                throw new NotDirectoryException(getString(path));
+            List<Path> list = new ArrayList<>();
+            IndexNode child = inode.child;
+            while (child != null) {
+                // (1) Assume each path from the zip file itself is "normalized"
+                // (2) IndexNode.name is absolute. see IndexNode(byte[],int,int)
+                // (3) If parent "dir" is relative when ZipDirectoryStream
+                //     is created, the returned child path needs to be relative
+                //     as well.
+                ZipPath childPath = new ZipPath(this, child.name, true);
+                ZipPath childFileName = childPath.getFileName();
+                ZipPath zpath = dir.resolve(childFileName);
+                if (filter == null || filter.accept(zpath))
+                    list.add(zpath);
+                child = child.sibling;
+            }
+            return list.iterator();
+        } finally {
+            endWrite();
+        }
+    }
+
+    void createDirectory(byte[] dir, FileAttribute<?>... attrs) throws IOException {
+        checkWritable();
+        beginWrite();
+        try {
+            ensureOpen();
+            if (dir.length == 0 || exists(dir)) // root dir, or existing dir
+                throw new FileAlreadyExistsException(getString(dir));
+            checkParents(dir);
+            Entry e = supportPosix ? new PosixEntry(dir, Entry.NEW, true, METHOD_STORED, attrs)
+                    : new Entry(dir, Entry.NEW, true, METHOD_STORED, attrs);
+            update(e);
+        } finally {
+            endWrite();
+        }
+    }
+
+    void copyFile(boolean deletesrc, byte[] src, byte[] dst, CopyOption... options)
+            throws IOException {
+        checkWritable();
+        if (Arrays.equals(src, dst))
+            return; // do nothing, src and dst are the same
+
+        beginWrite();
+        try {
+            ensureOpen();
+            Entry eSrc = getEntry(src); // ensureOpen checked
+
+            if (eSrc == null)
+                throw new NoSuchFileException(getString(src));
+            if (eSrc.isDir()) { // spec says to create dst dir
+                createDirectory(dst);
+                return;
+            }
+            boolean hasReplace = false;
+            boolean hasCopyAttrs = false;
+            for (CopyOption opt : options) {
+                if (opt == REPLACE_EXISTING)
+                    hasReplace = true;
+                else if (opt == COPY_ATTRIBUTES)
+                    hasCopyAttrs = true;
+            }
+            Entry eDst = getEntry(dst);
+            if (eDst != null) {
+                if (!hasReplace)
+                    throw new FileAlreadyExistsException(getString(dst));
+            } else {
+                checkParents(dst);
+            }
+            // copy eSrc entry and change name
+            Entry u = supportPosix ? new PosixEntry((PosixEntry) eSrc, Entry.COPY) : new Entry(eSrc, Entry.COPY);
+            u.name(dst);
+            if (eSrc.type == Entry.NEW || eSrc.type == Entry.FILECH) {
+                u.type = eSrc.type; // make it the same type
+                if (deletesrc) { // if it's a "rename", take the data
+                    u.bytes = eSrc.bytes;
+                    u.file = eSrc.file;
+                } else { // if it's not "rename", copy the data
+                    if (eSrc.bytes != null)
+                        u.bytes = Arrays.copyOf(eSrc.bytes, eSrc.bytes.length);
+                    else if (eSrc.file != null) {
+                        u.file = getTempPathForEntry(null);
+                        Files.copy(eSrc.file, u.file, REPLACE_EXISTING);
+                    }
+                }
+            } else if (eSrc.type == Entry.CEN && eSrc.method != defaultCompressionMethod) {
+
+                /**
+                 * We are copying a file within the same Zip file using a
+                 * different compression method.
+                 */
+                try (InputStream in = newInputStream(src);
+                        OutputStream out = newOutputStream(dst,
+                                CREATE, TRUNCATE_EXISTING, WRITE)) {
+                    in.transferTo(out);
+                }
+                u = getEntry(dst);
+            }
+
+            if (!hasCopyAttrs)
+                u.mtime = u.atime = u.ctime = System.currentTimeMillis();
+            update(u);
+            if (deletesrc)
+                updateDelete(eSrc);
+        } finally {
+            endWrite();
+        }
+    }
+
+    // Returns an output stream for writing the contents into the specified
+    // entry.
+    OutputStream newOutputStream(byte[] path, OpenOption... options)
+            throws IOException {
+        checkWritable();
+        boolean hasCreateNew = false;
+        boolean hasCreate = false;
+        boolean hasAppend = false;
+        boolean hasTruncate = false;
+        for (OpenOption opt : options) {
+            if (opt == READ)
+                throw new IllegalArgumentException("READ not allowed");
+            if (opt == CREATE_NEW)
+                hasCreateNew = true;
+            if (opt == CREATE)
+                hasCreate = true;
+            if (opt == APPEND)
+                hasAppend = true;
+            if (opt == TRUNCATE_EXISTING)
+                hasTruncate = true;
+        }
+        if (hasAppend && hasTruncate)
+            throw new IllegalArgumentException("APPEND + TRUNCATE_EXISTING not allowed");
+        beginRead(); // only need a readlock, the "update()" will
+        try { // try to obtain a writelock when the os is
+            ensureOpen(); // being closed.
+            Entry e = getEntry(path);
+            if (e != null) {
+                if (e.isDir() || hasCreateNew)
+                    throw new FileAlreadyExistsException(getString(path));
+                if (hasAppend) {
+                    OutputStream os = getOutputStream(new Entry(e, Entry.NEW));
+                    try (InputStream is = getInputStream(e)) {
+                        is.transferTo(os);
+                    }
+                    return os;
+                }
+                return getOutputStream(supportPosix ? new PosixEntry((PosixEntry) e, Entry.NEW, defaultCompressionMethod)
+                        : new Entry(e, Entry.NEW, defaultCompressionMethod));
+            } else {
+                if (!hasCreate && !hasCreateNew)
+                    throw new NoSuchFileException(getString(path));
+                checkParents(path);
+                return getOutputStream(supportPosix ? new PosixEntry(path, Entry.NEW, false, defaultCompressionMethod)
+                        : new Entry(path, Entry.NEW, false, defaultCompressionMethod));
+            }
+        } finally {
+            endRead();
+        }
+    }
+
+    // Returns an input stream for reading the contents of the specified
+    // file entry.
+    InputStream newInputStream(byte[] path) throws IOException {
+        beginRead();
+        try {
+            ensureOpen();
+            Entry e = getEntry(path);
+            if (e == null)
+                throw new NoSuchFileException(getString(path));
+            if (e.isDir())
+                throw new FileSystemException(getString(path), "is a directory", null);
+            return getInputStream(e);
+        } finally {
+            endRead();
+        }
+    }
+
+    private void checkOptions(Set<? extends OpenOption> options) {
+        // check for options of null type and option is an intance of StandardOpenOption
+        for (OpenOption option : options) {
+            if (option == null)
+                throw new NullPointerException();
+            if (!(option instanceof StandardOpenOption))
+                throw new IllegalArgumentException();
+        }
+        if (options.contains(APPEND) && options.contains(TRUNCATE_EXISTING))
+            throw new IllegalArgumentException("APPEND + TRUNCATE_EXISTING not allowed");
+    }
+
+    // Returns an output SeekableByteChannel for either
+    // (1) writing the contents of a new entry, if the entry doesn't exist, or
+    // (2) updating/replacing the contents of an existing entry.
+    // Note: The content of the channel is not compressed until the
+    // channel is closed
+    private class EntryOutputChannel extends ByteArrayChannel {
+        final Entry e;
+
+        EntryOutputChannel(Entry e) {
+            super(e.size > 0 ? (int) e.size : 8192, false);
+            this.e = e;
+            if (e.mtime == -1)
+                e.mtime = System.currentTimeMillis();
+            if (e.method == -1)
+                e.method = defaultCompressionMethod;
+            // store size, compressed size, and crc-32 in datadescriptor
+            e.flag = FLAG_DATADESCR;
+            if (zc.isUTF8())
+                e.flag |= FLAG_USE_UTF8;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.beginWrite();
+            try {
+                if (!isOpen())
+                    return;
+                // will update the entry
+                try (OutputStream os = getOutputStream(e)) {
+                    os.write(toByteArray());
+                }
+                super.close();
+            } finally {
+                super.endWrite();
+            }
+        }
+    }
+
+    // Returns a Writable/ReadByteChannel for now. Might consider to use
+    // newFileChannel() instead, which dump the entry data into a regular
+    // file on the default file system and create a FileChannel on top of it.
+    SeekableByteChannel newByteChannel(byte[] path,
+            Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs)
+            throws IOException {
+        checkOptions(options);
+        if (options.contains(StandardOpenOption.WRITE) ||
+                options.contains(StandardOpenOption.APPEND)) {
+            checkWritable();
+            beginRead(); // only need a read lock, the "update()" will obtain
+                         // the write lock when the channel is closed
+            ensureOpen();
+            try {
+                Entry e = getEntry(path);
+                if (e != null) {
+                    if (e.isDir() || options.contains(CREATE_NEW))
+                        throw new FileAlreadyExistsException(getString(path));
+                    SeekableByteChannel sbc = new EntryOutputChannel(
+                            supportPosix ? new PosixEntry((PosixEntry) e, Entry.NEW) : new Entry(e, Entry.NEW));
+                    if (options.contains(APPEND)) {
+                        try (InputStream is = getInputStream(e)) { // copyover
+                            byte[] buf = new byte[8192];
+                            ByteBuffer bb = ByteBuffer.wrap(buf);
+                            int n;
+                            while ((n = is.read(buf)) != -1) {
+                                bb.position(0);
+                                bb.limit(n);
+                                sbc.write(bb);
+                            }
+                        }
+                    }
+                    return sbc;
+                }
+                if (!options.contains(CREATE) && !options.contains(CREATE_NEW))
+                    throw new NoSuchFileException(getString(path));
+                checkParents(path);
+                return new EntryOutputChannel(
+                        supportPosix ? new PosixEntry(path, Entry.NEW, false, defaultCompressionMethod, attrs)
+                                : new Entry(path, Entry.NEW, false, defaultCompressionMethod, attrs));
+            } finally {
+                endRead();
+            }
+        } else {
+            beginRead();
+            try {
+                ensureOpen();
+                Entry e = getEntry(path);
+                if (e == null || e.isDir())
+                    throw new NoSuchFileException(getString(path));
+                try (InputStream is = getInputStream(e)) {
+                    // TBD: if (e.size < NNNNN);
+                    return new ByteArrayChannel(is.readAllBytes(), true);
+                }
+            } finally {
+                endRead();
+            }
+        }
+    }
+
+    // Returns a FileChannel of the specified entry.
+    //
+    // This implementation creates a temporary file on the default file system,
+    // copy the entry data into it if the entry exists, and then create a
+    // FileChannel on top of it.
+    FileChannel newFileChannel(byte[] path,
+            Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs)
+            throws IOException {
+        checkOptions(options);
+        final boolean forWrite = (options.contains(StandardOpenOption.WRITE) ||
+                options.contains(StandardOpenOption.APPEND));
+        beginRead();
+        try {
+            ensureOpen();
+            Entry e = getEntry(path);
+            if (forWrite) {
+                checkWritable();
+                if (e == null) {
+                    if (!options.contains(StandardOpenOption.CREATE) &&
+                            !options.contains(StandardOpenOption.CREATE_NEW)) {
+                        throw new NoSuchFileException(getString(path));
+                    }
+                } else {
+                    if (options.contains(StandardOpenOption.CREATE_NEW)) {
+                        throw new FileAlreadyExistsException(getString(path));
+                    }
+                    if (e.isDir())
+                        throw new FileAlreadyExistsException("directory <"
+                                + getString(path) + "> exists");
+                }
+                options = new HashSet<>(options);
+                options.remove(StandardOpenOption.CREATE_NEW); // for tmpfile
+            } else if (e == null || e.isDir()) {
+                throw new NoSuchFileException(getString(path));
+            }
+
+            final boolean isFCH = (e != null && e.type == Entry.FILECH);
+            final Path tmpfile = isFCH ? e.file : getTempPathForEntry(path);
+            final FileChannel fch = tmpfile.getFileSystem()
+                    .provider()
+                    .newFileChannel(tmpfile, options, attrs);
+            final Entry u = isFCH ? e
+                    : (supportPosix ? new PosixEntry(path, tmpfile, Entry.FILECH, attrs)
+                            : new Entry(path, tmpfile, Entry.FILECH, attrs));
+            if (forWrite) {
+                u.flag = FLAG_DATADESCR;
+                u.method = defaultCompressionMethod;
+            }
+            // is there a better way to hook into the FileChannel's close method?
+            return new FileChannel() {
+                public int write(ByteBuffer src) throws IOException {
+                    return fch.write(src);
+                }
+
+                public long write(ByteBuffer[] srcs, int offset, int length)
+                        throws IOException {
+                    return fch.write(srcs, offset, length);
+                }
+
+                public long position() throws IOException {
+                    return fch.position();
+                }
+
+                public FileChannel position(long newPosition)
+                        throws IOException {
+                    fch.position(newPosition);
+                    return this;
+                }
+
+                public long size() throws IOException {
+                    return fch.size();
+                }
+
+                public FileChannel truncate(long size)
+                        throws IOException {
+                    fch.truncate(size);
+                    return this;
+                }
+
+                public void force(boolean metaData)
+                        throws IOException {
+                    fch.force(metaData);
+                }
+
+                public long transferTo(long position, long count,
+                        WritableByteChannel target)
+                        throws IOException {
+                    return fch.transferTo(position, count, target);
+                }
+
+                public long transferFrom(ReadableByteChannel src,
+                        long position, long count)
+                        throws IOException {
+                    return fch.transferFrom(src, position, count);
+                }
+
+                public int read(ByteBuffer dst) throws IOException {
+                    return fch.read(dst);
+                }
+
+                public int read(ByteBuffer dst, long position)
+                        throws IOException {
+                    return fch.read(dst, position);
+                }
+
+                public long read(ByteBuffer[] dsts, int offset, int length)
+                        throws IOException {
+                    return fch.read(dsts, offset, length);
+                }
+
+                public int write(ByteBuffer src, long position)
+                        throws IOException {
+                    return fch.write(src, position);
+                }
+
+                public MappedByteBuffer map(MapMode mode,
+                        long position, long size) {
+                    throw new UnsupportedOperationException();
+                }
+
+                public FileLock lock(long position, long size, boolean shared)
+                        throws IOException {
+                    return fch.lock(position, size, shared);
+                }
+
+                public FileLock tryLock(long position, long size, boolean shared)
+                        throws IOException {
+                    return fch.tryLock(position, size, shared);
+                }
+
+                protected void implCloseChannel() throws IOException {
+                    fch.close();
+                    if (forWrite) {
+                        u.mtime = System.currentTimeMillis();
+                        u.size = Files.size(u.file);
+                        update(u);
+                    } else {
+                        if (!isFCH) // if this is a new fch for reading
+                            removeTempPathForEntry(tmpfile);
+                    }
+                }
+            };
+        } finally {
+            endRead();
+        }
+    }
+
+    // the outstanding input streams that need to be closed
+    private Set<InputStream> streams = Collections.synchronizedSet(new HashSet<>());
+
+    private final Set<Path> tmppaths = Collections.synchronizedSet(new HashSet<>());
+
+    private Path getTempPathForEntry(byte[] path) throws IOException {
+        Path tmpPath = createTempFileInSameDirectoryAs(zfpath);
+        if (path != null) {
+            Entry e = getEntry(path);
+            if (e != null) {
+                try (InputStream is = newInputStream(path)) {
+                    Files.copy(is, tmpPath, REPLACE_EXISTING);
+                }
+            }
+        }
+        return tmpPath;
+    }
+
+    private void removeTempPathForEntry(Path path) throws IOException {
+        Files.delete(path);
+        tmppaths.remove(path);
+    }
+
+    // check if all parents really exist. ZIP spec does not require
+    // the existence of any "parent directory".
+    private void checkParents(byte[] path) throws IOException {
+        beginRead();
+        try {
+            while ((path = getParent(path)) != null &&
+                    path != ROOTPATH) {
+                if (!inodes.containsKey(IndexNode.keyOf(path))) {
+                    throw new NoSuchFileException(getString(path));
+                }
+            }
+        } finally {
+            endRead();
+        }
+    }
+
+    private static byte[] getParent(byte[] path) {
+        int off = getParentOff(path);
+        if (off <= 1)
+            return ROOTPATH;
+        return Arrays.copyOf(path, off);
+    }
+
+    private static int getParentOff(byte[] path) {
+        int off = path.length - 1;
+        if (off > 0 && path[off] == '/') // isDirectory
+            off--;
+        while (off > 0 && path[off] != '/') {
+            off--;
+        }
+        return off;
+    }
+
+    private void beginWrite() {
+        rwlock.writeLock().lock();
+    }
+
+    private void endWrite() {
+        rwlock.writeLock().unlock();
+    }
+
+    private void beginRead() {
+        rwlock.readLock().lock();
+    }
+
+    private void endRead() {
+        rwlock.readLock().unlock();
+    }
+
+    ///////////////////////////////////////////////////////////////////
+
+    private volatile boolean isOpen = true;
+    private final SeekableByteChannel ch; // channel to the zipfile
+    final byte[] cen; // CEN & ENDHDR
+    private END end;
+    private long locpos; // position of first LOC header (usually 0)
+
+    private final ReadWriteLock rwlock = new ReentrantReadWriteLock();
+
+    // name -> pos (in cen), IndexNode itself can be used as a "key"
+    private LinkedHashMap<IndexNode, IndexNode> inodes;
+
+    final byte[] getBytes(String name) {
+        return zc.getBytes(name);
+    }
+
+    final String getString(byte[] name) {
+        return zc.toString(name);
+    }
+
+    @SuppressWarnings("deprecation")
+    protected void finalize() throws IOException {
+        close();
+    }
+
+    // Reads len bytes of data from the specified offset into buf.
+    // Returns the total number of bytes read.
+    // Each/every byte read from here (except the cen, which is mapped).
+    final long readFullyAt(byte[] buf, int off, long len, long pos)
+            throws IOException {
+        ByteBuffer bb = ByteBuffer.wrap(buf);
+        bb.position(off);
+        bb.limit((int) (off + len));
+        return readFullyAt(bb, pos);
+    }
+
+    private long readFullyAt(ByteBuffer bb, long pos) throws IOException {
+        if (ch instanceof FileChannel) {
+            FileChannel fch = (FileChannel) ch;
+            return fch.read(bb, pos);
+        } else {
+            synchronized (ch) {
+                return ch.position(pos).read(bb);
+            }
+        }
+    }
+
+    // Searches for end of central directory (END) header. The contents of
+    // the END header will be read and placed in endbuf. Returns the file
+    // position of the END header, otherwise returns -1 if the END header
+    // was not found or an error occurred.
+    private END findEND() throws IOException {
+        byte[] buf = new byte[READBLOCKSZ];
+        long ziplen = ch.size();
+        long minHDR = (ziplen - END_MAXLEN) > 0 ? ziplen - END_MAXLEN : 0;
+        long minPos = minHDR - (buf.length - ENDHDR);
+
+        for (long pos = ziplen - buf.length; pos >= minPos; pos -= (buf.length - ENDHDR)) {
+            int off = 0;
+            if (pos < 0) {
+                // Pretend there are some NUL bytes before start of file
+                off = (int) -pos;
+                Arrays.fill(buf, 0, off, (byte) 0);
+            }
+            int len = buf.length - off;
+            if (readFullyAt(buf, off, len, pos + off) != len)
+                throw new ZipException("zip END header not found");
+
+            // Now scan the block backwards for END header signature
+            for (int i = buf.length - ENDHDR; i >= 0; i--) {
+                if (buf[i] == (byte) 'P' &&
+                        buf[i + 1] == (byte) 'K' &&
+                        buf[i + 2] == (byte) '\005' &&
+                        buf[i + 3] == (byte) '\006' &&
+                        (pos + i + ENDHDR + ENDCOM(buf, i) == ziplen)) {
+                    // Found END header
+                    buf = Arrays.copyOfRange(buf, i, i + ENDHDR);
+                    END end = new END();
+                    // end.endsub = ENDSUB(buf); // not used
+                    end.centot = ENDTOT(buf);
+                    end.cenlen = ENDSIZ(buf);
+                    end.cenoff = ENDOFF(buf);
+                    // end.comlen = ENDCOM(buf); // not used
+                    end.endpos = pos + i;
+                    // try if there is zip64 end;
+                    byte[] loc64 = new byte[ZIP64_LOCHDR];
+                    if (end.endpos < ZIP64_LOCHDR ||
+                            readFullyAt(loc64, 0, loc64.length, end.endpos - ZIP64_LOCHDR) != loc64.length ||
+                            !locator64SigAt(loc64, 0)) {
+                        return end;
+                    }
+                    long end64pos = ZIP64_LOCOFF(loc64);
+                    byte[] end64buf = new byte[ZIP64_ENDHDR];
+                    if (readFullyAt(end64buf, 0, end64buf.length, end64pos) != end64buf.length ||
+                            !end64SigAt(end64buf, 0)) {
+                        return end;
+                    }
+                    // end64 found,
+                    long cenlen64 = ZIP64_ENDSIZ(end64buf);
+                    long cenoff64 = ZIP64_ENDOFF(end64buf);
+                    long centot64 = ZIP64_ENDTOT(end64buf);
+                    // double-check
+                    if (cenlen64 != end.cenlen && end.cenlen != ZIP64_MINVAL ||
+                            cenoff64 != end.cenoff && end.cenoff != ZIP64_MINVAL ||
+                            centot64 != end.centot && end.centot != ZIP64_MINVAL32) {
+                        return end;
+                    }
+                    // to use the end64 values
+                    end.cenlen = cenlen64;
+                    end.cenoff = cenoff64;
+                    end.centot = (int) centot64; // assume total < 2g
+                    end.endpos = end64pos;
+                    return end;
+                }
+            }
+        }
+        throw new ZipException("zip END header not found");
+    }
+
+    private void makeParentDirs(IndexNode node, IndexNode root) {
+        IndexNode parent;
+        ParentLookup lookup = new ParentLookup();
+        while (true) {
+            int off = getParentOff(node.name);
+            // parent is root
+            if (off <= 1) {
+                node.sibling = root.child;
+                root.child = node;
+                break;
+            }
+            // parent exists
+            lookup = lookup.as(node.name, off);
+            if (inodes.containsKey(lookup)) {
+                parent = inodes.get(lookup);
+                node.sibling = parent.child;
+                parent.child = node;
+                break;
+            }
+            // parent does not exist, add new pseudo directory entry
+            parent = new IndexNode(Arrays.copyOf(node.name, off), true);
+            inodes.put(parent, parent);
+            node.sibling = parent.child;
+            parent.child = node;
+            node = parent;
+        }
+    }
+
+    // ZIP directory has two issues:
+    // (1) ZIP spec does not require the ZIP file to include
+    //     directory entry
+    // (2) all entries are not stored/organized in a "tree"
+    //     structure.
+    // A possible solution is to build the node tree ourself as
+    // implemented below.
+    private void buildNodeTree() {
+        beginWrite();
+        try {
+            IndexNode root = inodes.remove(LOOKUPKEY.as(ROOTPATH));
+            if (root == null) {
+                root = new IndexNode(ROOTPATH, true);
+            }
+            IndexNode[] nodes = inodes.values().toArray(new IndexNode[0]);
+            inodes.put(root, root);
+            for (IndexNode node : nodes) {
+                makeParentDirs(node, root);
+            }
+        } finally {
+            endWrite();
+        }
+    }
+
+    private void removeFromTree(IndexNode inode) {
+        IndexNode parent = inodes.get(LOOKUPKEY.as(getParent(inode.name)));
+        IndexNode child = parent.child;
+        if (child.equals(inode)) {
+            parent.child = child.sibling;
+        } else {
+            IndexNode last = child;
+            while ((child = child.sibling) != null) {
+                if (child.equals(inode)) {
+                    last.sibling = child.sibling;
+                    break;
+                } else {
+                    last = child;
+                }
+            }
+        }
+    }
+
+    /**
+     * If a version property has been specified and the file represents a multi-release JAR,
+     * determine the requested runtime version and initialize the ZipFileSystem instance accordingly.
+     *
+     * Checks if the Zip File System property "releaseVersion" has been specified. If it has,
+     * use its value to determine the requested version. If not use the value of the "multi-release" property.
+     */
+    private void initializeReleaseVersion(Map<String, ?> env) throws IOException {
+        Object o = env.containsKey(PROPERTY_RELEASE_VERSION) ? env.get(PROPERTY_RELEASE_VERSION)
+                : env.get(PROPERTY_MULTI_RELEASE);
+
+        if (o != null && isMultiReleaseJar()) {
+            int version;
+            if (o instanceof String) {
+                String s = (String) o;
+                if (s.equals("runtime")) {
+                    version = Runtime.version().feature();
+                } else if (s.matches("^[1-9][0-9]*$")) {
+                    version = Version.parse(s).feature();
+                } else {
+                    throw new IllegalArgumentException("Invalid runtime version");
+                }
+            } else if (o instanceof Integer) {
+                version = Version.parse(((Integer) o).toString()).feature();
+            } else if (o instanceof Version) {
+                version = ((Version) o).feature();
+            } else {
+                throw new IllegalArgumentException("env parameter must be String, " +
+                        "Integer, or Version");
+            }
+            createVersionedLinks(version < 0 ? 0 : version);
+            setReadOnly();
+        }
+    }
+
+    /**
+     * Returns true if the Manifest main attribute "Multi-Release" is set to true; false otherwise.
+     */
+    private boolean isMultiReleaseJar() throws IOException {
+        try (InputStream is = newInputStream(getBytes("/META-INF/MANIFEST.MF"))) {
+            String multiRelease = new Manifest(is).getMainAttributes()
+                    .getValue(Attributes.Name.MULTI_RELEASE);
+            return "true".equalsIgnoreCase(multiRelease);
+        } catch (NoSuchFileException x) {
+            return false;
+        }
+    }
+
+    /**
+     * Create a map of aliases for versioned entries, for example:
+     * version/PackagePrivate.class -> META-INF/versions/9/version/PackagePrivate.class
+     * version/PackagePrivate.java -> META-INF/versions/9/version/PackagePrivate.java
+     * version/Version.class -> META-INF/versions/10/version/Version.class
+     * version/Version.java -> META-INF/versions/10/version/Version.java
+     *
+     * Then wrap the map in a function that getEntry can use to override root
+     * entry lookup for entries that have corresponding versioned entries.
+     */
+    private void createVersionedLinks(int version) {
+        IndexNode verdir = getInode(getBytes("/META-INF/versions"));
+        // nothing to do, if no /META-INF/versions
+        if (verdir == null) {
+            return;
+        }
+        // otherwise, create a map and for each META-INF/versions/{n} directory
+        // put all the leaf inodes, i.e. entries, into the alias map
+        // possibly shadowing lower versioned entries
+        HashMap<IndexNode, byte[]> aliasMap = new HashMap<>();
+        getVersionMap(version, verdir).values().forEach(versionNode -> walk(versionNode.child, entryNode -> aliasMap.put(
+                getOrCreateInode(getRootName(entryNode, versionNode), entryNode.isdir),
+                entryNode.name)));
+        entryLookup = path -> {
+            byte[] entry = aliasMap.get(IndexNode.keyOf(path));
+            return entry == null ? path : entry;
+        };
+    }
+
+    /**
+     * Create a sorted version map of version -> inode, for inodes <= max version.
+     * 9 -> META-INF/versions/9
+     * 10 -> META-INF/versions/10
+     */
+    private TreeMap<Integer, IndexNode> getVersionMap(int version, IndexNode metaInfVersions) {
+        TreeMap<Integer, IndexNode> map = new TreeMap<>();
+        IndexNode child = metaInfVersions.child;
+        while (child != null) {
+            Integer key = getVersion(child, metaInfVersions);
+            if (key != null && key <= version) {
+                map.put(key, child);
+            }
+            child = child.sibling;
+        }
+        return map;
+    }
+
+    /**
+     * Extract the integer version number -- META-INF/versions/9 returns 9.
+     */
+    private Integer getVersion(IndexNode inode, IndexNode metaInfVersions) {
+        try {
+            byte[] fullName = inode.name;
+            return Integer.parseInt(getString(Arrays
+                    .copyOfRange(fullName, metaInfVersions.name.length + 1, fullName.length)));
+        } catch (NumberFormatException x) {
+            // ignore this even though it might indicate issues with the JAR structure
+            return null;
+        }
+    }
+
+    /**
+     * Walk the IndexNode tree processing all leaf nodes.
+     */
+    private void walk(IndexNode inode, Consumer<IndexNode> consumer) {
+        if (inode == null)
+            return;
+        if (inode.isDir()) {
+            walk(inode.child, consumer);
+        } else {
+            consumer.accept(inode);
+        }
+        walk(inode.sibling, consumer);
+    }
+
+    /**
+     * Extract the root name from a versioned entry name.
+     * E.g. given inode 'META-INF/versions/9/foo/bar.class'
+     * and prefix 'META-INF/versions/9/' returns 'foo/bar.class'.
+     */
+    private byte[] getRootName(IndexNode inode, IndexNode prefix) {
+        byte[] fullName = inode.name;
+        return Arrays.copyOfRange(fullName, prefix.name.length, fullName.length);
+    }
+
+    // Reads zip file central directory. Returns the file position of first
+    // CEN header, otherwise returns -1 if an error occurred. If zip->msg != NULL
+    // then the error was a zip format error and zip->msg has the error text.
+    // Always pass in -1 for knownTotal; it's used for a recursive call.
+    private byte[] initCEN() throws IOException {
+        end = findEND();
+        if (end.endpos == 0) {
+            inodes = new LinkedHashMap<>(10);
+            locpos = 0;
+            buildNodeTree();
+            return null; // only END header present
+        }
+        if (end.cenlen > end.endpos)
+            throw new ZipException("invalid END header (bad central directory size)");
+        long cenpos = end.endpos - end.cenlen; // position of CEN table
+
+        // Get position of first local file (LOC) header, taking into
+        // account that there may be a stub prefixed to the zip file.
+        locpos = cenpos - end.cenoff;
+        if (locpos < 0)
+            throw new ZipException("invalid END header (bad central directory offset)");
+
+        // read in the CEN and END
+        byte[] cen = new byte[(int) (end.cenlen + ENDHDR)];
+        if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
+            throw new ZipException("read CEN tables failed");
+        }
+        // Iterate through the entries in the central directory
+        inodes = new LinkedHashMap<>(end.centot + 1);
+        int pos = 0;
+        int limit = cen.length - ENDHDR;
+        while (pos < limit) {
+            if (!cenSigAt(cen, pos))
+                throw new ZipException("invalid CEN header (bad signature)");
+            int method = CENHOW(cen, pos);
+            int nlen = CENNAM(cen, pos);
+            int elen = CENEXT(cen, pos);
+            int clen = CENCOM(cen, pos);
+            int flag = CENFLG(cen, pos);
+            if ((flag & 1) != 0) {
+                throw new ZipException("invalid CEN header (encrypted entry)");
+            }
+            if (method != METHOD_STORED && method != METHOD_DEFLATED) {
+                throw new ZipException("invalid CEN header (unsupported compression method: " + method + ")");
+            }
+            if (pos + CENHDR + nlen > limit) {
+                throw new ZipException("invalid CEN header (bad header size)");
+            }
+            IndexNode inode = new IndexNode(cen, pos, nlen);
+            inodes.put(inode, inode);
+            if (zc.isUTF8() || (flag & FLAG_USE_UTF8) != 0) {
+                checkUTF8(inode.name);
+            } else {
+                checkEncoding(inode.name);
+            }
+            // skip ext and comment
+            pos += (CENHDR + nlen + elen + clen);
+        }
+        if (pos + ENDHDR != cen.length) {
+            throw new ZipException("invalid CEN header (bad header size)");
+        }
+        buildNodeTree();
+        return cen;
+    }
+
+    private final void checkUTF8(byte[] a) throws ZipException {
+        try {
+            int end = a.length;
+            int pos = 0;
+            while (pos < end) {
+                // ASCII fast-path: When checking that a range of bytes is
+                // valid UTF-8, we can avoid some allocation by skipping
+                // past bytes in the 0-127 range
+                if (a[pos] < 0) {
+                    zc.toString(Arrays.copyOfRange(a, pos, a.length));
+                    break;
+                }
+                pos++;
+            }
+        } catch (Exception e) {
+            throw new ZipException("invalid CEN header (bad entry name)");
+        }
+    }
+
+    private final void checkEncoding(byte[] a) throws ZipException {
+        try {
+            zc.toString(a);
+        } catch (Exception e) {
+            throw new ZipException("invalid CEN header (bad entry name)");
+        }
+    }
+
+    private void ensureOpen() {
+        if (!isOpen)
+            throw new ClosedFileSystemException();
+    }
+
+    // Creates a new empty temporary file in the same directory as the
+    // specified file.  A variant of Files.createTempFile.
+    private Path createTempFileInSameDirectoryAs(Path path) throws IOException {
+        Path parent = path.toAbsolutePath().getParent();
+        Path dir = (parent == null) ? path.getFileSystem().getPath(".") : parent;
+        Path tmpPath = Files.createTempFile(dir, "zipfstmp", null);
+        tmppaths.add(tmpPath);
+        return tmpPath;
+    }
+
+    ////////////////////update & sync //////////////////////////////////////
+
+    private boolean hasUpdate = false;
+
+    // shared key. consumer guarantees the "writeLock" before use it.
+    private final IndexNode LOOKUPKEY = new IndexNode(null, -1);
+
+    private void updateDelete(IndexNode inode) {
+        beginWrite();
+        try {
+            removeFromTree(inode);
+            inodes.remove(inode);
+            hasUpdate = true;
+        } finally {
+            endWrite();
+        }
+    }
+
+    private void update(Entry e) {
+        beginWrite();
+        try {
+            IndexNode old = inodes.put(e, e);
+            if (old != null) {
+                removeFromTree(old);
+            }
+            if (e.type == Entry.NEW || e.type == Entry.FILECH || e.type == Entry.COPY) {
+                IndexNode parent = inodes.get(LOOKUPKEY.as(getParent(e.name)));
+                e.sibling = parent.child;
+                parent.child = e;
+            }
+            hasUpdate = true;
+        } finally {
+            endWrite();
+        }
+    }
+
+    // copy over the whole LOC entry (header if necessary, data and ext) from
+    // old zip to the new one.
+    private long copyLOCEntry(Entry e, boolean updateHeader,
+            OutputStream os,
+            long written, byte[] buf)
+            throws IOException {
+        long locoff = e.locoff; // where to read
+        e.locoff = written; // update the e.locoff with new value
+
+        // calculate the size need to write out
+        long size = 0;
+        //  if there is A ext
+        if ((e.flag & FLAG_DATADESCR) != 0) {
+            if (e.size >= ZIP64_MINVAL || e.csize >= ZIP64_MINVAL)
+                size = 24;
+            else
+                size = 16;
+        }
+        // read loc, use the original loc.elen/nlen
+        //
+        // an extra byte after loc is read, which should be the first byte of the
+        // 'name' field of the loc. if this byte is '/', which means the original
+        // entry has an absolute path in original zip/jar file, the e.writeLOC()
+        // is used to output the loc, in which the leading "/" will be removed
+        if (readFullyAt(buf, 0, LOCHDR + 1, locoff) != LOCHDR + 1)
+            throw new ZipException("loc: reading failed");
+
+        if (updateHeader || LOCNAM(buf) > 0 && buf[LOCHDR] == '/') {
+            locoff += LOCHDR + LOCNAM(buf) + LOCEXT(buf); // skip header
+            size += e.csize;
+            written = e.writeLOC(os) + size;
+        } else {
+            os.write(buf, 0, LOCHDR); // write out the loc header
+            locoff += LOCHDR;
+            // use e.csize,  LOCSIZ(buf) is zero if FLAG_DATADESCR is on
+            // size += LOCNAM(buf) + LOCEXT(buf) + LOCSIZ(buf);
+            size += LOCNAM(buf) + LOCEXT(buf) + e.csize;
+            written = LOCHDR + size;
+        }
+        int n;
+        while (size > 0 &&
+                (n = (int) readFullyAt(buf, 0, buf.length, locoff)) != -1) {
+            if (size < n)
+                n = (int) size;
+            os.write(buf, 0, n);
+            size -= n;
+            locoff += n;
+        }
+        return written;
+    }
+
+    private long writeEntry(Entry e, OutputStream os)
+            throws IOException {
+
+        if (e.bytes == null && e.file == null) // dir, 0-length data
+            return 0;
+
+        long written = 0;
+        if (e.method != METHOD_STORED && e.csize > 0 && (e.crc != 0 || e.size == 0)) {
+            // pre-compressed entry, write directly to output stream
+            writeTo(e, os);
+        } else {
+            try (OutputStream os2 = (e.method == METHOD_STORED) ? new EntryOutputStreamCRC32(e, os)
+                    : new EntryOutputStreamDef(e, os)) {
+                writeTo(e, os2);
+            }
+        }
+        written += e.csize;
+        if ((e.flag & FLAG_DATADESCR) != 0) {
+            written += e.writeEXT(os);
+        }
+        return written;
+    }
+
+    private void writeTo(Entry e, OutputStream os) throws IOException {
+        if (e.bytes != null) {
+            os.write(e.bytes, 0, e.bytes.length);
+        } else if (e.file != null) {
+            if (e.type == Entry.NEW || e.type == Entry.FILECH) {
+                try (InputStream is = Files.newInputStream(e.file)) {
+                    is.transferTo(os);
+                }
+            }
+            Files.delete(e.file);
+            tmppaths.remove(e.file);
+        }
+    }
+
+    // sync the zip file system, if there is any update
+    private void sync() throws IOException {
+        if (!hasUpdate)
+            return;
+        PosixFileAttributes attrs = getPosixAttributes(zfpath);
+        Path tmpFile = createTempFileInSameDirectoryAs(zfpath);
+        try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(tmpFile, WRITE))) {
+            ArrayList<Entry> elist = new ArrayList<>(inodes.size());
+            long written = 0;
+            byte[] buf = null;
+            Entry e;
+
+            final IndexNode manifestInode = inodes.get(
+                    IndexNode.keyOf(getBytes("/META-INF/MANIFEST.MF")));
+            final Iterator<IndexNode> inodeIterator = inodes.values().iterator();
+            boolean manifestProcessed = false;
+
+            // write loc
+            while (inodeIterator.hasNext()) {
+                final IndexNode inode;
+
+                // write the manifest inode (if any) first so that
+                // java.util.jar.JarInputStream can find it
+                if (manifestInode == null) {
+                    inode = inodeIterator.next();
+                } else {
+                    if (manifestProcessed) {
+                        // advance to next node, filtering out the manifest
+                        // which was already written
+                        inode = inodeIterator.next();
+                        if (inode == manifestInode) {
+                            continue;
+                        }
+                    } else {
+                        inode = manifestInode;
+                        manifestProcessed = true;
+                    }
+                }
+
+                if (inode instanceof Entry) { // an updated inode
+                    e = (Entry) inode;
+                    try {
+                        if (e.type == Entry.COPY) {
+                            // entry copy: the only thing changed is the "name"
+                            // and "nlen" in LOC header, so we update/rewrite the
+                            // LOC in new file and simply copy the rest (data and
+                            // ext) without enflating/deflating from the old zip
+                            // file LOC entry.
+                            if (buf == null)
+                                buf = new byte[8192];
+                            written += copyLOCEntry(e, true, os, written, buf);
+                        } else { // NEW, FILECH or CEN
+                            e.locoff = written;
+                            written += e.writeLOC(os); // write loc header
+                            written += writeEntry(e, os);
+                        }
+                        elist.add(e);
+                    } catch (IOException x) {
+                        x.printStackTrace(); // skip any in-accurate entry
+                    }
+                } else { // unchanged inode
+                    if (inode.pos == -1) {
+                        continue; // pseudo directory node
+                    }
+                    if (inode.name.length == 1 && inode.name[0] == '/') {
+                        continue; // no root '/' directory even if it
+                                  // exists in original zip/jar file.
+                    }
+                    e = supportPosix ? new PosixEntry(this, inode) : new Entry(this, inode);
+                    try {
+                        if (buf == null)
+                            buf = new byte[8192];
+                        written += copyLOCEntry(e, false, os, written, buf);
+                        elist.add(e);
+                    } catch (IOException x) {
+                        x.printStackTrace(); // skip any wrong entry
+                    }
+                }
+            }
+
+            // now write back the cen and end table
+            end.cenoff = written;
+            for (Entry entry : elist) {
+                written += entry.writeCEN(os);
+            }
+            end.centot = elist.size();
+            end.cenlen = written - end.cenoff;
+            end.write(os, written, forceEnd64);
+        }
+        ch.close();
+        Files.delete(zfpath);
+
+        // Set the POSIX permissions of the original Zip File if available
+        // before moving the temp file
+        if (attrs != null) {
+            Files.setPosixFilePermissions(tmpFile, attrs.permissions());
+        }
+        Files.move(tmpFile, zfpath, REPLACE_EXISTING);
+        hasUpdate = false; // clear
+    }
+
+    /**
+     * Returns a file's POSIX file attributes.
+     * 
+     * @param path The path to the file
+     * @return The POSIX file attributes for the specified file or
+     *         null if the POSIX attribute view is not available
+     * @throws IOException If an error occurs obtaining the POSIX attributes for
+     *         the specified file
+     */
+    private PosixFileAttributes getPosixAttributes(Path path) throws IOException {
+        try {
+            PosixFileAttributeView view = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+            // Return if the attribute view is not supported
+            if (view == null) {
+                return null;
+            }
+            return view.readAttributes();
+        } catch (UnsupportedOperationException e) {
+            // PosixFileAttributes not available
+            return null;
+        }
+    }
+
+    private IndexNode getInode(byte[] path) {
+        return inodes.get(IndexNode.keyOf(Objects.requireNonNull(entryLookup.apply(path), "path")));
+    }
+
+    /**
+     * Return the IndexNode from the root tree. If it doesn't exist,
+     * it gets created along with all parent directory IndexNodes.
+     */
+    private IndexNode getOrCreateInode(byte[] path, boolean isdir) {
+        IndexNode node = getInode(path);
+        // if node exists, return it
+        if (node != null) {
+            return node;
+        }
+
+        // otherwise create new pseudo node and parent directory hierarchy
+        node = new IndexNode(path, isdir);
+        beginWrite();
+        try {
+            makeParentDirs(node, Objects.requireNonNull(inodes.get(IndexNode.keyOf(ROOTPATH)), "no root node found"));
+            return node;
+        } finally {
+            endWrite();
+        }
+    }
+
+    private Entry getEntry(byte[] path) throws IOException {
+        IndexNode inode = getInode(path);
+        if (inode instanceof Entry)
+            return (Entry) inode;
+        if (inode == null || inode.pos == -1)
+            return null;
+        return supportPosix ? new PosixEntry(this, inode) : new Entry(this, inode);
+    }
+
+    public void deleteFile(byte[] path, boolean failIfNotExists)
+            throws IOException {
+        checkWritable();
+        IndexNode inode = getInode(path);
+        if (inode == null) {
+            if (path != null && path.length == 0)
+                throw new ZipException("root directory </> cannot be deleted");
+            if (failIfNotExists)
+                throw new NoSuchFileException(getString(path));
+        } else {
+            if (inode.isDir() && inode.child != null)
+                throw new DirectoryNotEmptyException(getString(path));
+            updateDelete(inode);
+        }
+    }
+
+    // Returns an out stream for either
+    // (1) writing the contents of a new entry, if the entry exists, or
+    // (2) updating/replacing the contents of the specified existing entry.
+    private OutputStream getOutputStream(Entry e) throws IOException {
+        if (e.mtime == -1)
+            e.mtime = System.currentTimeMillis();
+        if (e.method == -1)
+            e.method = defaultCompressionMethod;
+        // store size, compressed size, and crc-32 in datadescr
+        e.flag = FLAG_DATADESCR;
+        if (zc.isUTF8())
+            e.flag |= FLAG_USE_UTF8;
+        OutputStream os;
+        if (useTempFile) {
+            e.file = getTempPathForEntry(null);
+            os = Files.newOutputStream(e.file, WRITE);
+        } else {
+            os = new ByteArrayOutputStream((e.size > 0) ? (int) e.size : 8192);
+        }
+        if (e.method == METHOD_DEFLATED) {
+            return new DeflatingEntryOutputStream(e, os);
+        } else {
+            return new EntryOutputStream(e, os);
+        }
+    }
+
+    private class EntryOutputStream extends FilterOutputStream {
+        private final Entry e;
+        private long written;
+        private boolean isClosed;
+
+        EntryOutputStream(Entry e, OutputStream os) {
+            super(os);
+            this.e = Objects.requireNonNull(e, "Zip entry is null");
+            // this.written = 0;
+        }
+
+        @Override
+        public synchronized void write(int b) throws IOException {
+            out.write(b);
+            written += 1;
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len)
+                throws IOException {
+            out.write(b, off, len);
+            written += len;
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            if (isClosed) {
+                return;
+            }
+            isClosed = true;
+            e.size = written;
+            if (out instanceof ByteArrayOutputStream)
+                e.bytes = ((ByteArrayOutputStream) out).toByteArray();
+            super.close();
+            update(e);
+        }
+    }
+
+    // Output stream returned when writing "deflated" entries into memory,
+    // to enable eager (possibly parallel) deflation and reduce memory required.
+    private class DeflatingEntryOutputStream extends DeflaterOutputStream {
+        private final CRC32 crc;
+        private final Entry e;
+        private boolean isClosed;
+
+        DeflatingEntryOutputStream(Entry e, OutputStream os) {
+            super(os, getDeflater());
+            this.e = Objects.requireNonNull(e, "Zip entry is null");
+            this.crc = new CRC32();
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len)
+                throws IOException {
+            super.write(b, off, len);
+            crc.update(b, off, len);
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            if (isClosed)
+                return;
+            isClosed = true;
+            finish();
+            e.size = def.getBytesRead();
+            e.csize = def.getBytesWritten();
+            e.crc = crc.getValue();
+            if (out instanceof ByteArrayOutputStream)
+                e.bytes = ((ByteArrayOutputStream) out).toByteArray();
+            super.close();
+            update(e);
+            releaseDeflater(def);
+        }
+    }
+
+    // Wrapper output stream class to write out a "stored" entry.
+    // (1) this class does not close the underlying out stream when
+    //     being closed.
+    // (2) no need to be "synchronized", only used by sync()
+    private class EntryOutputStreamCRC32 extends FilterOutputStream {
+        private final CRC32 crc;
+        private final Entry e;
+        private long written;
+        private boolean isClosed;
+
+        EntryOutputStreamCRC32(Entry e, OutputStream os) {
+            super(os);
+            this.e = Objects.requireNonNull(e, "Zip entry is null");
+            this.crc = new CRC32();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+            crc.update(b);
+            written += 1;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len)
+                throws IOException {
+            out.write(b, off, len);
+            crc.update(b, off, len);
+            written += len;
+        }
+
+        @Override
+        public void close() {
+            if (isClosed)
+                return;
+            isClosed = true;
+            e.size = e.csize = written;
+            e.crc = crc.getValue();
+        }
+    }
+
+    // Wrapper output stream class to write out a "deflated" entry.
+    // (1) this class does not close the underlying out stream when
+    //     being closed.
+    // (2) no need to be "synchronized", only used by sync()
+    private class EntryOutputStreamDef extends DeflaterOutputStream {
+        private final CRC32 crc;
+        private final Entry e;
+        private boolean isClosed;
+
+        EntryOutputStreamDef(Entry e, OutputStream os) {
+            super(os, getDeflater());
+            this.e = Objects.requireNonNull(e, "Zip entry is null");
+            this.crc = new CRC32();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            super.write(b, off, len);
+            crc.update(b, off, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (isClosed)
+                return;
+            isClosed = true;
+            finish();
+            e.size = def.getBytesRead();
+            e.csize = def.getBytesWritten();
+            e.crc = crc.getValue();
+            releaseDeflater(def);
+        }
+    }
+
+    private InputStream getInputStream(Entry e)
+            throws IOException {
+        InputStream eis;
+        if (e.type == Entry.NEW) {
+            if (e.bytes != null)
+                eis = new ByteArrayInputStream(e.bytes);
+            else if (e.file != null)
+                eis = Files.newInputStream(e.file);
+            else
+                throw new ZipException("update entry data is missing");
+        } else if (e.type == Entry.FILECH) {
+            // FILECH result is un-compressed.
+            eis = Files.newInputStream(e.file);
+            // TBD: wrap to hook close()
+            // streams.add(eis);
+            return eis;
+        } else { // untouched CEN or COPY
+            eis = new EntryInputStream(e);
+        }
+        if (e.method == METHOD_DEFLATED) {
+            // MORE: Compute good size for inflater stream:
+            long bufSize = e.size + 2; // Inflater likes a bit of slack
+            if (bufSize > 65536)
+                bufSize = 8192;
+            final long size = e.size;
+            eis = new InflaterInputStream(eis, getInflater(), (int) bufSize) {
+                private boolean isClosed = false;
+
+                public void close() throws IOException {
+                    if (!isClosed) {
+                        releaseInflater(inf);
+                        this.in.close();
+                        isClosed = true;
+                        streams.remove(this);
+                    }
+                }
+
+                // Override fill() method to provide an extra "dummy" byte
+                // at the end of the input stream. This is required when
+                // using the "nowrap" Inflater option. (it appears the new
+                // zlib in 7 does not need it, but keep it for now)
+                protected void fill() throws IOException {
+                    if (eof) {
+                        throw new EOFException(
+                                "Unexpected end of ZLIB input stream");
+                    }
+                    len = this.in.read(buf, 0, buf.length);
+                    if (len == -1) {
+                        buf[0] = 0;
+                        len = 1;
+                        eof = true;
+                    }
+                    inf.setInput(buf, 0, len);
+                }
+
+                private boolean eof;
+
+                public int available() {
+                    if (isClosed)
+                        return 0;
+                    long avail = size - inf.getBytesWritten();
+                    return avail > (long) Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) avail;
+                }
+            };
+        } else if (e.method == METHOD_STORED) {
+            // TBD: wrap/ it does not seem necessary
+        } else {
+            throw new ZipException("invalid compression method");
+        }
+        streams.add(eis);
+        return eis;
+    }
+
+    // Inner class implementing the input stream used to read
+    // a (possibly compressed) zip file entry.
+    private class EntryInputStream extends InputStream {
+        private long pos; // current position within entry data
+        private long rem; // number of remaining bytes within entry
+
+        EntryInputStream(Entry e)
+                throws IOException {
+            rem = e.csize;
+            pos = e.locoff;
+            if (pos == -1) {
+                Entry e2 = getEntry(e.name);
+                if (e2 == null) {
+                    throw new ZipException("invalid loc for entry <" + getString(e.name) + ">");
+                }
+                pos = e2.locoff;
+            }
+            pos = -pos; // lazy initialize the real data offset
+        }
+
+        public int read(byte[] b, int off, int len) throws IOException {
+            ensureOpen();
+            initDataPos();
+            if (rem == 0) {
+                return -1;
+            }
+            if (len <= 0) {
+                return 0;
+            }
+            if (len > rem) {
+                len = (int) rem;
+            }
+            ByteBuffer bb = ByteBuffer.wrap(b);
+            bb.position(off);
+            bb.limit(off + len);
+            long n = readFullyAt(bb, pos);
+            if (n > 0) {
+                pos += n;
+                rem -= n;
+            }
+            if (rem == 0) {
+                close();
+            }
+            return (int) n;
+        }
+
+        public int read() throws IOException {
+            byte[] b = new byte[1];
+            if (read(b, 0, 1) == 1) {
+                return b[0] & 0xff;
+            } else {
+                return -1;
+            }
+        }
+
+        public long skip(long n) {
+            ensureOpen();
+            if (n > rem)
+                n = rem;
+            pos += n;
+            rem -= n;
+            if (rem == 0) {
+                close();
+            }
+            return n;
+        }
+
+        public int available() {
+            return rem > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) rem;
+        }
+
+        public void close() {
+            rem = 0;
+            streams.remove(this);
+        }
+
+        private void initDataPos() throws IOException {
+            if (pos <= 0) {
+                pos = -pos + locpos;
+                byte[] buf = new byte[LOCHDR];
+                if (readFullyAt(buf, 0, buf.length, pos) != LOCHDR) {
+                    throw new ZipException("invalid loc " + pos + " for entry reading");
+                }
+                pos += LOCHDR + LOCNAM(buf) + LOCEXT(buf);
+            }
+        }
+    }
+
+    // Maxmum number of de/inflater we cache
+    private final int MAX_FLATER = 20;
+    // List of available Inflater objects for decompression
+    private final List<Inflater> inflaters = new ArrayList<>();
+
+    // Gets an inflater from the list of available inflaters or allocates
+    // a new one.
+    private Inflater getInflater() {
+        synchronized (inflaters) {
+            int size = inflaters.size();
+            if (size > 0) {
+                return inflaters.remove(size - 1);
+            } else {
+                return new Inflater(true);
+            }
+        }
+    }
+
+    // Releases the specified inflater to the list of available inflaters.
+    private void releaseInflater(Inflater inf) {
+        synchronized (inflaters) {
+            if (inflaters.size() < MAX_FLATER) {
+                inf.reset();
+                inflaters.add(inf);
+            } else {
+                inf.end();
+            }
+        }
+    }
+
+    // List of available Deflater objects for compression
+    private final List<Deflater> deflaters = new ArrayList<>();
+
+    // Gets a deflater from the list of available deflaters or allocates
+    // a new one.
+    private Deflater getDeflater() {
+        synchronized (deflaters) {
+            int size = deflaters.size();
+            if (size > 0) {
+                return deflaters.remove(size - 1);
+            } else {
+                return new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+            }
+        }
+    }
+
+    // Releases the specified inflater to the list of available inflaters.
+    private void releaseDeflater(Deflater def) {
+        synchronized (deflaters) {
+            if (deflaters.size() < MAX_FLATER) {
+                def.reset();
+                deflaters.add(def);
+            } else {
+                def.end();
+            }
+        }
+    }
+
+    // End of central directory record
+    static class END {
+        // The fields that are commented out below are not used by anyone and write() uses "0"
+        // int  disknum;
+        // int  sdisknum;
+        // int  endsub;
+        int centot; // 4 bytes
+        long cenlen; // 4 bytes
+        long cenoff; // 4 bytes
+        // int  comlen;     // comment length
+        // byte[] comment;
+
+        // members of Zip64 end of central directory locator
+        // int diskNum;
+        long endpos;
+        // int disktot;
+
+        void write(OutputStream os, long offset, boolean forceEnd64) throws IOException {
+            boolean hasZip64 = forceEnd64; // false;
+            long xlen = cenlen;
+            long xoff = cenoff;
+            if (xlen >= ZIP64_MINVAL) {
+                xlen = ZIP64_MINVAL;
+                hasZip64 = true;
+            }
+            if (xoff >= ZIP64_MINVAL) {
+                xoff = ZIP64_MINVAL;
+                hasZip64 = true;
+            }
+            int count = centot;
+            if (count >= ZIP64_MINVAL32) {
+                count = ZIP64_MINVAL32;
+                hasZip64 = true;
+            }
+            if (hasZip64) {
+                //zip64 end of central directory record
+                writeInt(os, ZIP64_ENDSIG); // zip64 END record signature
+                writeLong(os, ZIP64_ENDHDR - 12); // size of zip64 end
+                writeShort(os, 45); // version made by
+                writeShort(os, 45); // version needed to extract
+                writeInt(os, 0); // number of this disk
+                writeInt(os, 0); // central directory start disk
+                writeLong(os, centot); // number of directory entries on disk
+                writeLong(os, centot); // number of directory entries
+                writeLong(os, cenlen); // length of central directory
+                writeLong(os, cenoff); // offset of central directory
+
+                //zip64 end of central directory locator
+                writeInt(os, ZIP64_LOCSIG); // zip64 END locator signature
+                writeInt(os, 0); // zip64 END start disk
+                writeLong(os, offset); // offset of zip64 END
+                writeInt(os, 1); // total number of disks (?)
+            }
+            writeInt(os, ENDSIG); // END record signature
+            writeShort(os, 0); // number of this disk
+            writeShort(os, 0); // central directory start disk
+            writeShort(os, count); // number of directory entries on disk
+            writeShort(os, count); // total number of directory entries
+            writeInt(os, xlen); // length of central directory
+            writeInt(os, xoff); // offset of central directory
+            writeShort(os, 0); // zip file comment, not used
+        }
+    }
+
+    // Internal node that links a "name" to its pos in cen table.
+    // The node itself can be used as a "key" to lookup itself in
+    // the HashMap inodes.
+    static class IndexNode {
+        byte[] name;
+        int hashcode; // node is hashable/hashed by its name
+        boolean isdir;
+        int pos = -1; // position in cen table, -1 means the
+                      // entry does not exist in zip file
+        IndexNode child; // first child
+        IndexNode sibling; // next sibling
+
+        IndexNode() {
+        }
+
+        IndexNode(byte[] name, boolean isdir) {
+            name(name);
+            this.isdir = isdir;
+            this.pos = -1;
+        }
+
+        IndexNode(byte[] name, int pos) {
+            name(name);
+            this.pos = pos;
+        }
+
+        // constructor for initCEN() (1) remove trailing '/' (2) pad leading '/'
+        IndexNode(byte[] cen, int pos, int nlen) {
+            int noff = pos + CENHDR;
+            if (cen[noff + nlen - 1] == '/') {
+                isdir = true;
+                nlen--;
+            }
+            if (nlen > 0 && cen[noff] == '/') {
+                name = Arrays.copyOfRange(cen, noff, noff + nlen);
+            } else {
+                name = new byte[nlen + 1];
+                System.arraycopy(cen, noff, name, 1, nlen);
+                name[0] = '/';
+            }
+            name(normalize(name));
+            this.pos = pos;
+        }
+
+        // Normalize the IndexNode.name field.
+        private byte[] normalize(byte[] path) {
+            int len = path.length;
+            if (len == 0)
+                return path;
+            byte prevC = 0;
+            for (int pathPos = 0; pathPos < len; pathPos++) {
+                byte c = path[pathPos];
+                if (c == '/' && prevC == '/')
+                    return normalize(path, pathPos - 1);
+                prevC = c;
+            }
+            if (len > 1 && prevC == '/') {
+                return Arrays.copyOf(path, len - 1);
+            }
+            return path;
+        }
+
+        private byte[] normalize(byte[] path, int off) {
+            // As we know we have at least one / to trim, we can reduce
+            // the size of the resulting array
+            byte[] to = new byte[path.length - 1];
+            int pathPos = 0;
+            while (pathPos < off) {
+                to[pathPos] = path[pathPos];
+                pathPos++;
+            }
+            int toPos = pathPos;
+            byte prevC = 0;
+            while (pathPos < path.length) {
+                byte c = path[pathPos++];
+                if (c == '/' && prevC == '/')
+                    continue;
+                to[toPos++] = c;
+                prevC = c;
+            }
+            if (toPos > 1 && to[toPos - 1] == '/')
+                toPos--;
+            return (toPos == to.length) ? to : Arrays.copyOf(to, toPos);
+        }
+
+        private static final ThreadLocal<IndexNode> cachedKey = new ThreadLocal<>();
+
+        static final IndexNode keyOf(byte[] name) { // get a lookup key;
+            IndexNode key = cachedKey.get();
+            if (key == null) {
+                key = new IndexNode(name, -1);
+                cachedKey.set(key);
+            }
+            return key.as(name);
+        }
+
+        final void name(byte[] name) {
+            this.name = name;
+            this.hashcode = Arrays.hashCode(name);
+        }
+
+        final IndexNode as(byte[] name) { // reuse the node, mostly
+            name(name); // as a lookup "key"
+            return this;
+        }
+
+        boolean isDir() {
+            return isdir;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof IndexNode)) {
+                return false;
+            }
+            if (other instanceof ParentLookup) {
+                return ((ParentLookup) other).equals(this);
+            }
+            return Arrays.equals(name, ((IndexNode) other).name);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashcode;
+        }
+
+        @Override
+        public String toString() {
+            return new String(name) + (isdir ? " (dir)" : " ") + ", index: " + pos;
+        }
+    }
+
+    static class Entry extends IndexNode implements ZipFileAttributes {
+        static final int CEN = 1; // entry read from cen
+        static final int NEW = 2; // updated contents in bytes or file
+        static final int FILECH = 3; // fch update in "file"
+        static final int COPY = 4; // copy of a CEN entry
+
+        byte[] bytes; // updated content bytes
+        Path file; // use tmp file to store bytes;
+        int type = CEN; // default is the entry read from cen
+
+        // entry attributes
+        int version;
+        int flag;
+        int posixPerms = -1; // posix permissions
+        int method = -1; // compression method
+        long mtime = -1; // last modification time (in DOS time)
+        long atime = -1; // last access time
+        long ctime = -1; // create time
+        long crc = -1; // crc-32 of entry data
+        long csize = -1; // compressed size of entry data
+        long size = -1; // uncompressed size of entry data
+        byte[] extra;
+
+        // CEN
+        // The fields that are commented out below are not used by anyone and write() uses "0"
+        // int    versionMade;
+        // int    disk;
+        // int    attrs;
+        // long   attrsEx;
+        long locoff;
+        byte[] comment;
+
+        Entry(byte[] name, boolean isdir, int method) {
+            name(name);
+            this.isdir = isdir;
+            this.mtime = this.ctime = this.atime = System.currentTimeMillis();
+            this.crc = 0;
+            this.size = 0;
+            this.csize = 0;
+            this.method = method;
+        }
+
+        @SuppressWarnings("unchecked")
+        Entry(byte[] name, int type, boolean isdir, int method, FileAttribute<?>... attrs) {
+            this(name, isdir, method);
+            this.type = type;
+            for (FileAttribute<?> attr : attrs) {
+                String attrName = attr.name();
+                if (attrName.equals("posix:permissions")) {
+                    posixPerms = ZipUtils.permsToFlags((Set<PosixFilePermission>) attr.value());
+                }
+            }
+        }
+
+        Entry(byte[] name, Path file, int type, FileAttribute<?>... attrs) {
+            this(name, type, false, METHOD_STORED, attrs);
+            this.file = file;
+        }
+
+        Entry(Entry e, int type, int compressionMethod) {
+            this(e, type);
+            this.method = compressionMethod;
+        }
+
+        Entry(Entry e, int type) {
+            name(e.name);
+            this.isdir = e.isdir;
+            this.version = e.version;
+            this.ctime = e.ctime;
+            this.atime = e.atime;
+            this.mtime = e.mtime;
+            this.crc = e.crc;
+            this.size = e.size;
+            this.csize = e.csize;
+            this.method = e.method;
+            this.extra = e.extra;
+            /*
+             * this.versionMade = e.versionMade;
+             * this.disk = e.disk;
+             * this.attrs = e.attrs;
+             * this.attrsEx = e.attrsEx;
+             */
+            this.locoff = e.locoff;
+            this.comment = e.comment;
+            this.posixPerms = e.posixPerms;
+            this.type = type;
+        }
+
+        Entry(ZipFileSystem zipfs, IndexNode inode) throws IOException {
+            readCEN(zipfs, inode);
+        }
+
+        // Calculates a suitable base for the version number to
+        // be used for fields version made by/version needed to extract.
+        // The lower bytes of these 2 byte fields hold the version number
+        // (value/10 = major; value%10 = minor)
+        // For different features certain minimum versions apply:
+        // stored = 10 (1.0), deflated = 20 (2.0), zip64 = 45 (4.5)
+        private int version(boolean zip64) throws ZipException {
+            if (zip64) {
+                return 45;
+            }
+            if (method == METHOD_DEFLATED)
+                return 20;
+            else if (method == METHOD_STORED)
+                return 10;
+            throw new ZipException("unsupported compression method");
+        }
+
+        /**
+         * Adds information about compatibility of file attribute information
+         * to a version value.
+         */
+        private int versionMadeBy(int version) {
+            return (posixPerms < 0) ? version : VERSION_MADE_BY_BASE_UNIX | (version & 0xff);
+        }
+
+        ///////////////////// CEN //////////////////////
+        private void readCEN(ZipFileSystem zipfs, IndexNode inode) throws IOException {
+            byte[] cen = zipfs.cen;
+            int pos = inode.pos;
+            if (!cenSigAt(cen, pos))
+                throw new ZipException("invalid CEN header (bad signature)");
+            version = CENVER(cen, pos);
+            flag = CENFLG(cen, pos);
+            method = CENHOW(cen, pos);
+            mtime = dosToJavaTime(CENTIM(cen, pos));
+            crc = CENCRC(cen, pos);
+            csize = CENSIZ(cen, pos);
+            size = CENLEN(cen, pos);
+            int nlen = CENNAM(cen, pos);
+            int elen = CENEXT(cen, pos);
+            int clen = CENCOM(cen, pos);
+            /*
+             * versionMade = CENVEM(cen, pos);
+             * disk = CENDSK(cen, pos);
+             * attrs = CENATT(cen, pos);
+             * attrsEx = CENATX(cen, pos);
+             */
+            if (CENVEM_FA(cen, pos) == FILE_ATTRIBUTES_UNIX) {
+                posixPerms = CENATX_PERMS(cen, pos) & 0xFFF; // 12 bits for setuid, setgid, sticky + perms
+            }
+            locoff = CENOFF(cen, pos);
+            pos += CENHDR;
+            this.name = inode.name;
+            this.isdir = inode.isdir;
+            this.hashcode = inode.hashcode;
+
+            pos += nlen;
+            if (elen > 0) {
+                extra = Arrays.copyOfRange(cen, pos, pos + elen);
+                pos += elen;
+                readExtra(zipfs);
+            }
+            if (clen > 0) {
+                comment = Arrays.copyOfRange(cen, pos, pos + clen);
+            }
+        }
+
+        private int writeCEN(OutputStream os) throws IOException {
+            long csize0 = csize;
+            long size0 = size;
+            long locoff0 = locoff;
+            int elen64 = 0; // extra for ZIP64
+            int elenNTFS = 0; // extra for NTFS (a/c/mtime)
+            int elenEXTT = 0; // extra for Extended Timestamp
+            boolean foundExtraTime = false; // if time stamp NTFS, EXTT present
+
+            byte[] zname = isdir ? toDirectoryPath(name) : name;
+
+            // confirm size/length
+            int nlen = (zname != null) ? zname.length - 1 : 0; // name has [0] as "slash"
+            int elen = (extra != null) ? extra.length : 0;
+            int eoff = 0;
+            int clen = (comment != null) ? comment.length : 0;
+            if (csize >= ZIP64_MINVAL) {
+                csize0 = ZIP64_MINVAL;
+                elen64 += 8; // csize(8)
+            }
+            if (size >= ZIP64_MINVAL) {
+                size0 = ZIP64_MINVAL; // size(8)
+                elen64 += 8;
+            }
+            if (locoff >= ZIP64_MINVAL) {
+                locoff0 = ZIP64_MINVAL;
+                elen64 += 8; // offset(8)
+            }
+            if (elen64 != 0) {
+                elen64 += 4; // header and data sz 4 bytes
+            }
+            boolean zip64 = (elen64 != 0);
+            int version0 = version(zip64);
+            while (eoff + 4 < elen) {
+                int tag = SH(extra, eoff);
+                int sz = SH(extra, eoff + 2);
+                if (tag == EXTID_EXTT || tag == EXTID_NTFS) {
+                    foundExtraTime = true;
+                }
+                eoff += (4 + sz);
+            }
+            if (!foundExtraTime) {
+                if (isWindows) { // use NTFS
+                    elenNTFS = 36; // total 36 bytes
+                } else { // Extended Timestamp otherwise
+                    elenEXTT = 9; // only mtime in cen
+                }
+            }
+            writeInt(os, CENSIG); // CEN header signature
+            writeShort(os, versionMadeBy(version0)); // version made by
+            writeShort(os, version0); // version needed to extract
+            writeShort(os, flag); // general purpose bit flag
+            writeShort(os, method); // compression method
+                                    // last modification time
+            writeInt(os, (int) javaToDosTime(mtime));
+            writeInt(os, crc); // crc-32
+            writeInt(os, csize0); // compressed size
+            writeInt(os, size0); // uncompressed size
+            writeShort(os, nlen);
+            writeShort(os, elen + elen64 + elenNTFS + elenEXTT);
+
+            if (comment != null) {
+                writeShort(os, Math.min(clen, 0xffff));
+            } else {
+                writeShort(os, 0);
+            }
+            writeShort(os, 0); // starting disk number
+            writeShort(os, 0); // internal file attributes (unused)
+            writeInt(os, posixPerms > 0 ? posixPerms << 16 : 0); // external file
+            // attributes, used for storing posix
+            // permissions
+            writeInt(os, locoff0); // relative offset of local header
+            writeBytes(os, zname, 1, nlen);
+            if (zip64) {
+                writeShort(os, EXTID_ZIP64);// Zip64 extra
+                writeShort(os, elen64 - 4); // size of "this" extra block
+                if (size0 == ZIP64_MINVAL)
+                    writeLong(os, size);
+                if (csize0 == ZIP64_MINVAL)
+                    writeLong(os, csize);
+                if (locoff0 == ZIP64_MINVAL)
+                    writeLong(os, locoff);
+            }
+            if (elenNTFS != 0) {
+                writeShort(os, EXTID_NTFS);
+                writeShort(os, elenNTFS - 4);
+                writeInt(os, 0); // reserved
+                writeShort(os, 0x0001); // NTFS attr tag
+                writeShort(os, 24);
+                writeLong(os, javaToWinTime(mtime));
+                writeLong(os, javaToWinTime(atime));
+                writeLong(os, javaToWinTime(ctime));
+            }
+            if (elenEXTT != 0) {
+                writeShort(os, EXTID_EXTT);
+                writeShort(os, elenEXTT - 4);
+                if (ctime == -1)
+                    os.write(0x3); // mtime and atime
+                else
+                    os.write(0x7); // mtime, atime and ctime
+                writeInt(os, javaToUnixTime(mtime));
+            }
+            if (extra != null) // whatever not recognized
+                writeBytes(os, extra);
+            if (comment != null) //TBD: 0, Math.min(commentBytes.length, 0xffff));
+                writeBytes(os, comment);
+            return CENHDR + nlen + elen + clen + elen64 + elenNTFS + elenEXTT;
+        }
+
+        ///////////////////// LOC //////////////////////
+
+        private int writeLOC(OutputStream os) throws IOException {
+            byte[] zname = isdir ? toDirectoryPath(name) : name;
+            int nlen = (zname != null) ? zname.length - 1 : 0; // [0] is slash
+            int elen = (extra != null) ? extra.length : 0;
+            boolean foundExtraTime = false; // if extra timestamp present
+            int eoff = 0;
+            int elen64 = 0;
+            boolean zip64 = false;
+            int elenEXTT = 0;
+            int elenNTFS = 0;
+            writeInt(os, LOCSIG); // LOC header signature
+            if ((flag & FLAG_DATADESCR) != 0) {
+                writeShort(os, version(false)); // version needed to extract
+                writeShort(os, flag); // general purpose bit flag
+                writeShort(os, method); // compression method
+                // last modification time
+                writeInt(os, (int) javaToDosTime(mtime));
+                // store size, uncompressed size, and crc-32 in data descriptor
+                // immediately following compressed entry data
+                writeInt(os, 0);
+                writeInt(os, 0);
+                writeInt(os, 0);
+            } else {
+                if (csize >= ZIP64_MINVAL || size >= ZIP64_MINVAL) {
+                    elen64 = 20; //headid(2) + size(2) + size(8) + csize(8)
+                    zip64 = true;
+                }
+                writeShort(os, version(zip64)); // version needed to extract
+                writeShort(os, flag); // general purpose bit flag
+                writeShort(os, method); // compression method
+                                        // last modification time
+                writeInt(os, (int) javaToDosTime(mtime));
+                writeInt(os, crc); // crc-32
+                if (zip64) {
+                    writeInt(os, ZIP64_MINVAL);
+                    writeInt(os, ZIP64_MINVAL);
+                } else {
+                    writeInt(os, csize); // compressed size
+                    writeInt(os, size); // uncompressed size
+                }
+            }
+            while (eoff + 4 < elen) {
+                int tag = SH(extra, eoff);
+                int sz = SH(extra, eoff + 2);
+                if (tag == EXTID_EXTT || tag == EXTID_NTFS) {
+                    foundExtraTime = true;
+                }
+                eoff += (4 + sz);
+            }
+            if (!foundExtraTime) {
+                if (isWindows) {
+                    elenNTFS = 36; // NTFS, total 36 bytes
+                } else { // on unix use "ext time"
+                    elenEXTT = 9;
+                    if (atime != -1)
+                        elenEXTT += 4;
+                    if (ctime != -1)
+                        elenEXTT += 4;
+                }
+            }
+            writeShort(os, nlen);
+            writeShort(os, elen + elen64 + elenNTFS + elenEXTT);
+            writeBytes(os, zname, 1, nlen);
+            if (zip64) {
+                writeShort(os, EXTID_ZIP64);
+                writeShort(os, 16);
+                writeLong(os, size);
+                writeLong(os, csize);
+            }
+            if (elenNTFS != 0) {
+                writeShort(os, EXTID_NTFS);
+                writeShort(os, elenNTFS - 4);
+                writeInt(os, 0); // reserved
+                writeShort(os, 0x0001); // NTFS attr tag
+                writeShort(os, 24);
+                writeLong(os, javaToWinTime(mtime));
+                writeLong(os, javaToWinTime(atime));
+                writeLong(os, javaToWinTime(ctime));
+            }
+            if (elenEXTT != 0) {
+                writeShort(os, EXTID_EXTT);
+                writeShort(os, elenEXTT - 4);// size for the folowing data block
+                int fbyte = 0x1;
+                if (atime != -1) // mtime and atime
+                    fbyte |= 0x2;
+                if (ctime != -1) // mtime, atime and ctime
+                    fbyte |= 0x4;
+                os.write(fbyte); // flags byte
+                writeInt(os, javaToUnixTime(mtime));
+                if (atime != -1)
+                    writeInt(os, javaToUnixTime(atime));
+                if (ctime != -1)
+                    writeInt(os, javaToUnixTime(ctime));
+            }
+            if (extra != null) {
+                writeBytes(os, extra);
+            }
+            return LOCHDR + nlen + elen + elen64 + elenNTFS + elenEXTT;
+        }
+
+        // Data Descriptor
+        private int writeEXT(OutputStream os) throws IOException {
+            writeInt(os, EXTSIG); // EXT header signature
+            writeInt(os, crc); // crc-32
+            if (csize >= ZIP64_MINVAL || size >= ZIP64_MINVAL) {
+                writeLong(os, csize);
+                writeLong(os, size);
+                return 24;
+            } else {
+                writeInt(os, csize); // compressed size
+                writeInt(os, size); // uncompressed size
+                return 16;
+            }
+        }
+
+        // read NTFS, UNIX and ZIP64 data from cen.extra
+        private void readExtra(ZipFileSystem zipfs) throws IOException {
+            // Note that Section 4.5, Extensible data fields, of the PKWARE ZIP File
+            // Format Specification does not mandate a specific order for the
+            // data in the extra field, therefore Zip FS cannot assume the data
+            // is written in the same order by Zip libraries as Zip FS.
+            if (extra == null)
+                return;
+            int elen = extra.length;
+            int off = 0;
+            int newOff = 0;
+            boolean hasZip64LocOffset = false;
+            while (off + 4 < elen) {
+                // extra spec: HeaderID+DataSize+Data
+                int pos = off;
+                int tag = SH(extra, pos);
+                int sz = SH(extra, pos + 2);
+                pos += 4;
+                if (pos + sz > elen) // invalid data
+                    break;
+                switch (tag) {
+                    case EXTID_ZIP64:
+                        if (size == ZIP64_MINVAL) {
+                            if (pos + 8 > elen) // invalid zip64 extra
+                                break; // fields, just skip
+                            size = LL(extra, pos);
+                            pos += 8;
+                        }
+                        if (csize == ZIP64_MINVAL) {
+                            if (pos + 8 > elen)
+                                break;
+                            csize = LL(extra, pos);
+                            pos += 8;
+                        }
+                        if (locoff == ZIP64_MINVAL) {
+                            if (pos + 8 > elen)
+                                break;
+                            locoff = LL(extra, pos);
+                        }
+                        break;
+                    case EXTID_NTFS:
+                        if (sz < 32)
+                            break;
+                        pos += 4; // reserved 4 bytes
+                        if (SH(extra, pos) != 0x0001)
+                            break;
+                        if (SH(extra, pos + 2) != 24)
+                            break;
+                        // override the loc field, datatime here is
+                        // more "accurate"
+                        mtime = winToJavaTime(LL(extra, pos + 4));
+                        atime = winToJavaTime(LL(extra, pos + 12));
+                        ctime = winToJavaTime(LL(extra, pos + 20));
+                        break;
+                    case EXTID_EXTT:
+                        // spec says the Extended timestamp in cen only has mtime
+                        // need to read the loc to get the extra a/ctime, if flag
+                        // "zipinfo-time" is not specified to false;
+                        // there is performance cost (move up to loc and read) to
+                        // access the loc table foreach entry;
+                        if (zipfs.noExtt) {
+                            if (sz == 5)
+                                mtime = unixToJavaTime(LG(extra, pos + 1));
+                            break;
+                        }
+                        // If the LOC offset is 0xFFFFFFFF, then we need to read the
+                        // LOC offset from the EXTID_ZIP64 extra data. Therefore
+                        // wait until all of the CEN extra data fields have been processed
+                        // prior to reading the LOC extra data field in order to obtain
+                        // the Info-ZIP Extended Timestamp.
+                        if (locoff != ZIP64_MINVAL) {
+                            readLocEXTT(zipfs);
+                        } else {
+                            hasZip64LocOffset = true;
+                        }
+                        break;
+                    default: // unknown tag
+                        System.arraycopy(extra, off, extra, newOff, sz + 4);
+                        newOff += (sz + 4);
+                }
+                off += (sz + 4);
+            }
+
+            // We need to read the LOC extra data and the LOC offset was obtained
+            // from the EXTID_ZIP64 field.
+            if (hasZip64LocOffset) {
+                readLocEXTT(zipfs);
+            }
+
+            if (newOff != 0 && newOff != extra.length)
+                extra = Arrays.copyOf(extra, newOff);
+            else
+                extra = null;
+        }
+
+        /**
+         * Read the LOC extra field to obtain the Info-ZIP Extended Timestamp fields
+         * 
+         * @param zipfs The Zip FS to use
+         * @throws IOException If an error occurs
+         */
+        private void readLocEXTT(ZipFileSystem zipfs) throws IOException {
+            byte[] buf = new byte[LOCHDR];
+            if (zipfs.readFullyAt(buf, 0, buf.length, locoff) != buf.length)
+                throw new ZipException("loc: reading failed");
+            if (!locSigAt(buf, 0))
+                throw new ZipException("R"
+                        + Long.toString(getSig(buf, 0), 16));
+            int locElen = LOCEXT(buf);
+            if (locElen < 9) // EXTT is at least 9 bytes
+                return;
+            int locNlen = LOCNAM(buf);
+            buf = new byte[locElen];
+            if (zipfs.readFullyAt(buf, 0, buf.length, locoff + LOCHDR + locNlen) != buf.length)
+                throw new ZipException("loc extra: reading failed");
+            int locPos = 0;
+            while (locPos + 4 < buf.length) {
+                int locTag = SH(buf, locPos);
+                int locSZ = SH(buf, locPos + 2);
+                locPos += 4;
+                if (locTag != EXTID_EXTT) {
+                    locPos += locSZ;
+                    continue;
+                }
+                int end = locPos + locSZ - 4;
+                int flag = CH(buf, locPos++);
+                if ((flag & 0x1) != 0 && locPos <= end) {
+                    mtime = unixToJavaTime(LG(buf, locPos));
+                    locPos += 4;
+                }
+                if ((flag & 0x2) != 0 && locPos <= end) {
+                    atime = unixToJavaTime(LG(buf, locPos));
+                    locPos += 4;
+                }
+                if ((flag & 0x4) != 0 && locPos <= end) {
+                    ctime = unixToJavaTime(LG(buf, locPos));
+                }
+                break;
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder(1024);
+            Formatter fm = new Formatter(sb);
+            fm.format("    name            : %s%n", new String(name));
+            fm.format("    creationTime    : %tc%n", creationTime().toMillis());
+            fm.format("    lastAccessTime  : %tc%n", lastAccessTime().toMillis());
+            fm.format("    lastModifiedTime: %tc%n", lastModifiedTime().toMillis());
+            fm.format("    isRegularFile   : %b%n", isRegularFile());
+            fm.format("    isDirectory     : %b%n", isDirectory());
+            fm.format("    isSymbolicLink  : %b%n", isSymbolicLink());
+            fm.format("    isOther         : %b%n", isOther());
+            fm.format("    fileKey         : %s%n", fileKey());
+            fm.format("    size            : %d%n", size());
+            fm.format("    compressedSize  : %d%n", compressedSize());
+            fm.format("    crc             : %x%n", crc());
+            fm.format("    method          : %d%n", method());
+            Set<PosixFilePermission> permissions = storedPermissions().orElse(null);
+            if (permissions != null) {
+                fm.format("    permissions     : %s%n", permissions);
+            }
+            fm.close();
+            return sb.toString();
+        }
+
+        ///////// basic file attributes ///////////
+        @Override
+        public FileTime creationTime() {
+            return FileTime.fromMillis(ctime == -1 ? mtime : ctime);
+        }
+
+        @Override
+        public boolean isDirectory() {
+            return isDir();
+        }
+
+        @Override
+        public boolean isOther() {
+            return false;
+        }
+
+        @Override
+        public boolean isRegularFile() {
+            return !isDir();
+        }
+
+        @Override
+        public FileTime lastAccessTime() {
+            return FileTime.fromMillis(atime == -1 ? mtime : atime);
+        }
+
+        @Override
+        public FileTime lastModifiedTime() {
+            return FileTime.fromMillis(mtime);
+        }
+
+        @Override
+        public long size() {
+            return size;
+        }
+
+        @Override
+        public boolean isSymbolicLink() {
+            return false;
+        }
+
+        @Override
+        public Object fileKey() {
+            return null;
+        }
+
+        ///////// zip file attributes ///////////
+
+        @Override
+        public long compressedSize() {
+            return csize;
+        }
+
+        @Override
+        public long crc() {
+            return crc;
+        }
+
+        @Override
+        public int method() {
+            return method;
+        }
+
+        @Override
+        public byte[] extra() {
+            if (extra != null)
+                return Arrays.copyOf(extra, extra.length);
+            return null;
+        }
+
+        @Override
+        public byte[] comment() {
+            if (comment != null)
+                return Arrays.copyOf(comment, comment.length);
+            return null;
+        }
+
+        @Override
+        public Optional<Set<PosixFilePermission>> storedPermissions() {
+            Set<PosixFilePermission> perms = null;
+            if (posixPerms != -1) {
+                perms = new HashSet<>(PosixFilePermission.values().length);
+                for (PosixFilePermission perm : PosixFilePermission.values()) {
+                    if ((posixPerms & ZipUtils.permToFlag(perm)) != 0) {
+                        perms.add(perm);
+                    }
+                }
+            }
+            return Optional.ofNullable(perms);
+        }
+    }
+
+    final class PosixEntry extends Entry implements PosixFileAttributes {
+        private UserPrincipal owner = defaultOwner;
+        private GroupPrincipal group = defaultGroup;
+
+        PosixEntry(byte[] name, boolean isdir, int method) {
+            super(name, isdir, method);
+        }
+
+        PosixEntry(byte[] name, int type, boolean isdir, int method, FileAttribute<?>... attrs) {
+            super(name, type, isdir, method, attrs);
+        }
+
+        PosixEntry(byte[] name, Path file, int type, FileAttribute<?>... attrs) {
+            super(name, file, type, attrs);
+        }
+
+        PosixEntry(PosixEntry e, int type, int compressionMethod) {
+            super(e, type);
+            this.method = compressionMethod;
+        }
+
+        PosixEntry(PosixEntry e, int type) {
+            super(e, type);
+            this.owner = e.owner;
+            this.group = e.group;
+        }
+
+        PosixEntry(ZipFileSystem zipfs, IndexNode inode) throws IOException {
+            super(zipfs, inode);
+        }
+
+        @Override
+        public UserPrincipal owner() {
+            return owner;
+        }
+
+        @Override
+        public GroupPrincipal group() {
+            return group;
+        }
+
+        @Override
+        public Set<PosixFilePermission> permissions() {
+            return storedPermissions().orElse(Set.copyOf(defaultPermissions));
+        }
+    }
+
+    // purely for parent lookup, so we don't have to copy the parent
+    // name every time
+    static class ParentLookup extends IndexNode {
+        int len;
+
+        ParentLookup() {
+        }
+
+        final ParentLookup as(byte[] name, int len) { // as a lookup "key"
+            name(name, len);
+            return this;
+        }
+
+        void name(byte[] name, int len) {
+            this.name = name;
+            this.len = len;
+            // calculate the hashcode the same way as Arrays.hashCode() does
+            int result = 1;
+            for (int i = 0; i < len; i++)
+                result = 31 * result + name[i];
+            this.hashcode = result;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof IndexNode)) {
+                return false;
+            }
+            byte[] oname = ((IndexNode) other).name;
+            return Arrays.equals(name, 0, len,
+                    oname, 0, oname.length);
+        }
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipFileSystemProvider.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipFileSystemProvider.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.DirectoryStream.Filter;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.ProviderMismatchException;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.zip.ZipException;
+
+/**
+ * @author Xueming Shen, Rajendra Gutupalli, Jaya Hangal
+ */
+public class ZipFileSystemProvider extends FileSystemProvider {
+    private final Map<Path, ZipFileSystem> filesystems = new HashMap<>();
+
+    public ZipFileSystemProvider() {
+    }
+
+    @Override
+    public String getScheme() {
+        return "jar";
+    }
+
+    protected Path uriToPath(URI uri) {
+        String scheme = uri.getScheme();
+        if ((scheme == null) || !scheme.equalsIgnoreCase(getScheme())) {
+            throw new IllegalArgumentException("URI scheme is not '" + getScheme() + "'");
+        }
+        try {
+            // only support legacy JAR URL syntax  jar:{uri}!/{entry} for now
+            String spec = uri.getRawSchemeSpecificPart();
+            int sep = spec.indexOf("!/");
+            if (sep != -1) {
+                spec = spec.substring(0, sep);
+            }
+            return Paths.get(new URI(spec)).toAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private boolean ensureFile(Path path) {
+        try {
+            BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+            if (!attrs.isRegularFile())
+                throw new UnsupportedOperationException();
+            return true;
+        } catch (IOException ioe) {
+            return false;
+        }
+    }
+
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env)
+            throws IOException {
+        Path path = uriToPath(uri);
+        synchronized (filesystems) {
+            Path realPath = null;
+            if (ensureFile(path)) {
+                realPath = path.toRealPath();
+                if (filesystems.containsKey(realPath))
+                    throw new FileSystemAlreadyExistsException();
+            }
+            ZipFileSystem zipfs = getZipFileSystem(path, env);
+            if (realPath == null) { // newly created
+                realPath = path.toRealPath();
+            }
+            filesystems.put(realPath, zipfs);
+            return zipfs;
+        }
+    }
+
+    @Override
+    public FileSystem newFileSystem(Path path, Map<String, ?> env)
+            throws IOException {
+        ensureFile(path);
+        return getZipFileSystem(path, env);
+    }
+
+    private ZipFileSystem getZipFileSystem(Path path, Map<String, ?> env) throws IOException {
+        try {
+            return new ZipFileSystem(this, path, env);
+        } catch (ZipException ze) {
+            String pname = path.toString();
+            if (pname.endsWith(".zip") || pname.endsWith(".jar"))
+                throw ze;
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public Path getPath(URI uri) {
+        String spec = uri.getSchemeSpecificPart();
+        int sep = spec.indexOf("!/");
+        if (sep == -1)
+            throw new IllegalArgumentException("URI: "
+                    + uri
+                    + " does not contain path info ex. jar:file:/c:/foo.zip!/BAR");
+        return getFileSystem(uri).getPath(spec.substring(sep + 1));
+    }
+
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        synchronized (filesystems) {
+            ZipFileSystem zipfs = null;
+            try {
+                zipfs = filesystems.get(uriToPath(uri).toRealPath());
+            } catch (IOException x) {
+                // ignore the ioe from toRealPath(), return FSNFE
+            }
+            if (zipfs == null)
+                throw new FileSystemNotFoundException();
+            return zipfs;
+        }
+    }
+
+    // Checks that the given file is a UnixPath
+    private static ZipPath toZipPath(Path path) {
+        if (path == null)
+            throw new NullPointerException();
+        if (!(path instanceof ZipPath))
+            throw new ProviderMismatchException();
+        return (ZipPath) path;
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        toZipPath(path).checkAccess(modes);
+    }
+
+    @Override
+    public void copy(Path src, Path target, CopyOption... options)
+            throws IOException {
+        toZipPath(src).copy(toZipPath(target), options);
+    }
+
+    @Override
+    public void createDirectory(Path path, FileAttribute<?>... attrs)
+            throws IOException {
+        toZipPath(path).createDirectory(attrs);
+    }
+
+    @Override
+    public final void delete(Path path) throws IOException {
+        toZipPath(path).delete();
+    }
+
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
+        return toZipPath(path).getFileAttributeView(type);
+    }
+
+    @Override
+    public FileStore getFileStore(Path path) throws IOException {
+        return toZipPath(path).getFileStore();
+    }
+
+    @Override
+    public boolean isHidden(Path path) {
+        return toZipPath(path).isHidden();
+    }
+
+    @Override
+    public boolean isSameFile(Path path, Path other) throws IOException {
+        return toZipPath(path).isSameFile(other);
+    }
+
+    @Override
+    public void move(Path src, Path target, CopyOption... options)
+            throws IOException {
+        toZipPath(src).move(toZipPath(target), options);
+    }
+
+    @Override
+    public AsynchronousFileChannel newAsynchronousFileChannel(Path path,
+            Set<? extends OpenOption> options,
+            ExecutorService exec,
+            FileAttribute<?>... attrs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path path,
+            Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs)
+            throws IOException {
+        return toZipPath(path).newByteChannel(options, attrs);
+    }
+
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(
+            Path path, Filter<? super Path> filter) throws IOException {
+        return toZipPath(path).newDirectoryStream(filter);
+    }
+
+    @Override
+    public FileChannel newFileChannel(Path path,
+            Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs)
+            throws IOException {
+        return toZipPath(path).newFileChannel(options, attrs);
+    }
+
+    @Override
+    public InputStream newInputStream(Path path, OpenOption... options)
+            throws IOException {
+        return toZipPath(path).newInputStream(options);
+    }
+
+    @Override
+    public OutputStream newOutputStream(Path path, OpenOption... options)
+            throws IOException {
+        return toZipPath(path).newOutputStream(options);
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options)
+            throws IOException {
+        return toZipPath(path).readAttributes(type);
+    }
+
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options)
+            throws IOException {
+        return toZipPath(path).readAttributes(attributes, options);
+    }
+
+    @Override
+    public Path readSymbolicLink(Path link) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void setAttribute(Path path, String attribute,
+            Object value, LinkOption... options)
+            throws IOException {
+        toZipPath(path).setAttribute(attribute, value, options);
+    }
+
+    //////////////////////////////////////////////////////////////
+    @SuppressWarnings("removal")
+    void removeFileSystem(Path zfpath, ZipFileSystem zfs) throws IOException {
+        synchronized (filesystems) {
+            Path tempPath = zfpath;
+            PrivilegedExceptionAction<Path> action = tempPath::toRealPath;
+            try {
+                zfpath = AccessController.doPrivileged(action);
+            } catch (PrivilegedActionException e) {
+                throw (IOException) e.getException();
+            }
+            if (filesystems.get(zfpath) == zfs)
+                filesystems.remove(zfpath);
+        }
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipInfo.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipInfo.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENATT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENATX;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENCOM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENCRC;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENDSK;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENEXT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENFLG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENHOW;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENLEN;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENNAM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENOFF;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENSIZ;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENTIM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENVEM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.CENVER;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTID_EXTT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTID_NTFS;
+import static io.quarkus.fs.util.zipfs.ZipConstants.EXTID_ZIP64;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LL;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCCRC;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCEXT;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCFLG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCHDR;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCHOW;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCLEN;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCNAM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCSIG;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCSIZ;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCTIM;
+import static io.quarkus.fs.util.zipfs.ZipConstants.LOCVER;
+import static io.quarkus.fs.util.zipfs.ZipConstants.SH;
+import static io.quarkus.fs.util.zipfs.ZipConstants.ZIP64_MINVAL;
+import static io.quarkus.fs.util.zipfs.ZipUtils.dosToJavaTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.unixToJavaTime;
+import static io.quarkus.fs.util.zipfs.ZipUtils.winToJavaTime;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import java.util.zip.ZipException;
+
+/**
+ * Print all loc and cen headers of the ZIP file
+ *
+ * @author Xueming Shen
+ */
+public class ZipInfo {
+
+    public static void main(String[] args) throws Throwable {
+        if (args.length < 1) {
+            print("Usage: java ZipInfo zfname");
+        } else {
+            Map<String, ?> env = Collections.emptyMap();
+            ZipFileSystem zfs = (ZipFileSystem) (new ZipFileSystemProvider()
+                    .newFileSystem(Paths.get(args[0]), env));
+            byte[] cen = zfs.cen;
+            if (cen == null) {
+                print("zip file is empty%n");
+                return;
+            }
+            int pos = 0;
+            byte[] buf = new byte[1024];
+            int no = 1;
+            while (pos + CENHDR < cen.length) {
+                print("----------------#%d--------------------%n", no++);
+                printCEN(cen, pos);
+
+                // use size CENHDR as the extra bytes to read, just in case the
+                // loc.extra is bigger than the cen.extra, try to avoid to read
+                // twice
+                long len = LOCHDR + CENNAM(cen, pos) + CENEXT(cen, pos) + CENHDR;
+                if (zfs.readFullyAt(buf, 0, len, locoff(cen, pos)) != len)
+                    throw new ZipException("read loc header failed");
+                if (LOCEXT(buf) > CENEXT(cen, pos) + CENHDR) {
+                    // have to read the second time;
+                    len = LOCHDR + LOCNAM(buf) + LOCEXT(buf);
+                    if (zfs.readFullyAt(buf, 0, len, locoff(cen, pos)) != len)
+                        throw new ZipException("read loc header failed");
+                }
+                printLOC(buf);
+                pos += CENHDR + CENNAM(cen, pos) + CENEXT(cen, pos) + CENCOM(cen, pos);
+            }
+            zfs.close();
+        }
+    }
+
+    private static void print(String fmt, Object... objs) {
+        System.out.printf(fmt, objs);
+    }
+
+    private static void printLOC(byte[] loc) {
+        print("%n");
+        print("[Local File Header]%n");
+        print("    Signature   :   %#010x%n", LOCSIG(loc));
+        if (LOCSIG(loc) != LOCSIG) {
+            print("    Wrong signature!");
+            return;
+        }
+        print("    Version     :       %#6x    [%d.%d]%n",
+                LOCVER(loc), LOCVER(loc) / 10, LOCVER(loc) % 10);
+        print("    Flag        :       %#6x%n", LOCFLG(loc));
+        print("    Method      :       %#6x%n", LOCHOW(loc));
+        print("    LastMTime   :   %#10x    [%tc]%n",
+                LOCTIM(loc), dosToJavaTime(LOCTIM(loc)));
+        print("    CRC         :   %#10x%n", LOCCRC(loc));
+        print("    CSize       :   %#10x%n", LOCSIZ(loc));
+        print("    Size        :   %#10x%n", LOCLEN(loc));
+        print("    NameLength  :       %#6x    [%s]%n",
+                LOCNAM(loc), new String(loc, LOCHDR, LOCNAM(loc)));
+        print("    ExtraLength :       %#6x%n", LOCEXT(loc));
+        if (LOCEXT(loc) != 0)
+            printExtra(loc, LOCHDR + LOCNAM(loc), LOCEXT(loc));
+    }
+
+    private static void printCEN(byte[] cen, int off) {
+        print("[Central Directory Header]%n");
+        print("    Signature   :   %#010x%n", CENSIG(cen, off));
+        if (CENSIG(cen, off) != CENSIG) {
+            print("    Wrong signature!");
+            return;
+        }
+        print("    VerMadeby   :       %#6x    [%d, %d.%d]%n",
+                CENVEM(cen, off), (CENVEM(cen, off) >> 8),
+                (CENVEM(cen, off) & 0xff) / 10,
+                (CENVEM(cen, off) & 0xff) % 10);
+        print("    VerExtract  :       %#6x    [%d.%d]%n",
+                CENVER(cen, off), CENVER(cen, off) / 10, CENVER(cen, off) % 10);
+        print("    Flag        :       %#6x%n", CENFLG(cen, off));
+        print("    Method      :       %#6x%n", CENHOW(cen, off));
+        print("    LastMTime   :   %#10x    [%tc]%n",
+                CENTIM(cen, off), dosToJavaTime(CENTIM(cen, off)));
+        print("    CRC         :   %#10x%n", CENCRC(cen, off));
+        print("    CSize       :   %#10x%n", CENSIZ(cen, off));
+        print("    Size        :   %#10x%n", CENLEN(cen, off));
+        print("    NameLen     :       %#6x    [%s]%n",
+                CENNAM(cen, off), new String(cen, off + CENHDR, CENNAM(cen, off)));
+        print("    ExtraLen    :       %#6x%n", CENEXT(cen, off));
+        if (CENEXT(cen, off) != 0)
+            printExtra(cen, off + CENHDR + CENNAM(cen, off), CENEXT(cen, off));
+        print("    CommentLen  :       %#6x%n", CENCOM(cen, off));
+        print("    DiskStart   :       %#6x%n", CENDSK(cen, off));
+        print("    Attrs       :       %#6x%n", CENATT(cen, off));
+        print("    AttrsEx     :   %#10x%n", CENATX(cen, off));
+        print("    LocOff      :   %#10x%n", CENOFF(cen, off));
+
+    }
+
+    private static long locoff(byte[] cen, int pos) {
+        long locoff = CENOFF(cen, pos);
+        if (locoff == ZIP64_MINVAL) { //ZIP64
+            int off = pos + CENHDR + CENNAM(cen, pos);
+            int end = off + CENEXT(cen, pos);
+            while (off + 4 < end) {
+                int tag = SH(cen, off);
+                int sz = SH(cen, off + 2);
+                if (tag != EXTID_ZIP64) {
+                    off += 4 + sz;
+                    continue;
+                }
+                off += 4;
+                if (CENLEN(cen, pos) == ZIP64_MINVAL)
+                    off += 8;
+                if (CENSIZ(cen, pos) == ZIP64_MINVAL)
+                    off += 8;
+                return LL(cen, off);
+            }
+            // should never be here
+        }
+        return locoff;
+    }
+
+    private static void printExtra(byte[] extra, int off, int len) {
+        int end = off + len;
+        while (off + 4 <= end) {
+            int tag = SH(extra, off);
+            int sz = SH(extra, off + 2);
+            print("        [tag=0x%04x, sz=%d, data= ", tag, sz);
+            if (off + sz > end) {
+                print("    Error: Invalid extra data, beyond extra length");
+                break;
+            }
+            off += 4;
+            for (int i = 0; i < sz; i++)
+                print("%02x ", extra[off + i]);
+            print("]%n");
+            switch (tag) {
+                case EXTID_ZIP64:
+                    print("         ->ZIP64: ");
+                    int pos = off;
+                    while (pos + 8 <= off + sz) {
+                        print(" *0x%x ", LL(extra, pos));
+                        pos += 8;
+                    }
+                    print("%n");
+                    break;
+                case EXTID_NTFS:
+                    print("         ->PKWare NTFS%n");
+                    // 4 bytes reserved
+                    if (SH(extra, off + 4) != 0x0001 || SH(extra, off + 6) != 24)
+                        print("    Error: Invalid NTFS sub-tag or subsz");
+                    print("            mtime:%tc%n",
+                            winToJavaTime(LL(extra, off + 8)));
+                    print("            atime:%tc%n",
+                            winToJavaTime(LL(extra, off + 16)));
+                    print("            ctime:%tc%n",
+                            winToJavaTime(LL(extra, off + 24)));
+                    break;
+                case EXTID_EXTT:
+                    print("         ->Info-ZIP Extended Timestamp: flag=%x%n", extra[off]);
+                    pos = off + 1;
+                    while (pos + 4 <= off + sz) {
+                        print("            *%tc%n",
+                                unixToJavaTime(LG(extra, pos)));
+                        pos += 4;
+                    }
+                    break;
+                default:
+                    print("         ->[tag=%x, size=%d]%n", tag, sz);
+            }
+            off += sz;
+        }
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipPath.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipPath.java
@@ -1,0 +1,1056 @@
+/*
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.DirectoryStream.Filter;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.ProviderMismatchException;
+import java.nio.file.ReadOnlyFileSystemException;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileOwnerAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Xueming Shen, Rajendra Gutupalli,Jaya Hangal
+ */
+final class ZipPath implements Path {
+
+    private final ZipFileSystem zfs;
+    private final byte[] path;
+    private volatile int[] offsets;
+    private int hashcode = 0; // cached hashcode (created lazily)
+
+    ZipPath(ZipFileSystem zfs, byte[] path) {
+        this(zfs, path, false);
+    }
+
+    ZipPath(ZipFileSystem zfs, byte[] path, boolean normalized) {
+        this.zfs = zfs;
+        if (normalized) {
+            this.path = path;
+        } else {
+            if (zfs.zc.isUTF8()) {
+                this.path = normalize(path);
+            } else { // see normalize(String);
+                this.path = normalize(zfs.getString(path));
+            }
+        }
+    }
+
+    ZipPath(ZipFileSystem zfs, String path) {
+        this.zfs = zfs;
+        this.path = normalize(path);
+    }
+
+    @Override
+    public ZipPath getRoot() {
+        if (this.isAbsolute())
+            return zfs.getRootDir();
+        else
+            return null;
+    }
+
+    @Override
+    public ZipPath getFileName() {
+        int off = path.length;
+        if (off == 0 || off == 1 && path[0] == '/')
+            return null;
+        while (--off >= 0 && path[off] != '/') {
+        }
+        if (off < 0)
+            return this;
+        off++;
+        byte[] result = new byte[path.length - off];
+        System.arraycopy(path, off, result, 0, result.length);
+        return new ZipPath(getFileSystem(), result, true);
+    }
+
+    @Override
+    public ZipPath getParent() {
+        int off = path.length;
+        if (off == 0 || off == 1 && path[0] == '/')
+            return null;
+        while (--off >= 0 && path[off] != '/') {
+        }
+        if (off <= 0)
+            return getRoot();
+        byte[] result = new byte[off];
+        System.arraycopy(path, 0, result, 0, off);
+        return new ZipPath(getFileSystem(), result, true);
+    }
+
+    @Override
+    public int getNameCount() {
+        initOffsets();
+        return offsets.length;
+    }
+
+    @Override
+    public ZipPath getName(int index) {
+        initOffsets();
+        if (index < 0 || index >= offsets.length)
+            throw new IllegalArgumentException();
+        int begin = offsets[index];
+        int len;
+        if (index == (offsets.length - 1))
+            len = path.length - begin;
+        else
+            len = offsets[index + 1] - begin - 1;
+        // construct result
+        byte[] result = new byte[len];
+        System.arraycopy(path, begin, result, 0, len);
+        return new ZipPath(zfs, result);
+    }
+
+    @Override
+    public ZipPath subpath(int beginIndex, int endIndex) {
+        initOffsets();
+        if (beginIndex < 0 ||
+                beginIndex >= offsets.length ||
+                endIndex > offsets.length ||
+                beginIndex >= endIndex)
+            throw new IllegalArgumentException();
+
+        // starting offset and length
+        int begin = offsets[beginIndex];
+        int len;
+        if (endIndex == offsets.length)
+            len = path.length - begin;
+        else
+            len = offsets[endIndex] - begin - 1;
+        // construct result
+        byte[] result = new byte[len];
+        System.arraycopy(path, begin, result, 0, len);
+        return new ZipPath(zfs, result);
+    }
+
+    @Override
+    public ZipPath toRealPath(LinkOption... options) throws IOException {
+        ZipPath realPath;
+        byte[] resolved = getResolvedPath();
+        // resolved is always absolute and normalized
+        if (resolved == path) {
+            realPath = this;
+        } else {
+            realPath = new ZipPath(zfs, resolved, true);
+            realPath.resolved = resolved;
+        }
+        realPath.checkAccess();
+        return realPath;
+    }
+
+    boolean isHidden() {
+        return false;
+    }
+
+    @Override
+    public ZipPath toAbsolutePath() {
+        if (isAbsolute()) {
+            return this;
+        } else {
+            // add '/' before the existing path
+            byte[] tmp = new byte[path.length + 1];
+            System.arraycopy(path, 0, tmp, 1, path.length);
+            tmp[0] = '/';
+            return new ZipPath(zfs, tmp, true); // normalized
+        }
+    }
+
+    @Override
+    public URI toUri() {
+        try {
+            return new URI("jar",
+                    decodeUri(zfs.getZipFile().toUri().toString()) +
+                            "!" +
+                            zfs.getString(toAbsolutePath().path),
+                    null);
+        } catch (Exception ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    private boolean equalsNameAt(ZipPath other, int index) {
+        int mbegin = offsets[index];
+        int mlen;
+        if (index == (offsets.length - 1))
+            mlen = path.length - mbegin;
+        else
+            mlen = offsets[index + 1] - mbegin - 1;
+        int obegin = other.offsets[index];
+        int olen;
+        if (index == (other.offsets.length - 1))
+            olen = other.path.length - obegin;
+        else
+            olen = other.offsets[index + 1] - obegin - 1;
+        if (mlen != olen)
+            return false;
+        int n = 0;
+        while (n < mlen) {
+            if (path[mbegin + n] != other.path[obegin + n])
+                return false;
+            n++;
+        }
+        return true;
+    }
+
+    @Override
+    public Path relativize(Path other) {
+        final ZipPath o = checkPath(other);
+        if (o.equals(this))
+            return new ZipPath(zfs, new byte[0], true);
+        if (this.path.length == 0)
+            return o;
+        if (this.zfs != o.zfs || this.isAbsolute() != o.isAbsolute())
+            throw new IllegalArgumentException();
+        if (this.path.length == 1 && this.path[0] == '/')
+            return new ZipPath(zfs,
+                    Arrays.copyOfRange(o.path, 1, o.path.length),
+                    true);
+        int mc = this.getNameCount();
+        int oc = o.getNameCount();
+        int n = Math.min(mc, oc);
+        int i = 0;
+        while (i < n) {
+            if (!equalsNameAt(o, i))
+                break;
+            i++;
+        }
+        int dotdots = mc - i;
+        int len = dotdots * 3 - 1;
+        if (i < oc)
+            len += (o.path.length - o.offsets[i] + 1);
+        byte[] result = new byte[len];
+
+        int pos = 0;
+        while (dotdots > 0) {
+            result[pos++] = (byte) '.';
+            result[pos++] = (byte) '.';
+            if (pos < len) // no tailing slash at the end
+                result[pos++] = (byte) '/';
+            dotdots--;
+        }
+        if (i < oc)
+            System.arraycopy(o.path, o.offsets[i],
+                    result, pos,
+                    o.path.length - o.offsets[i]);
+        return new ZipPath(zfs, result);
+    }
+
+    @Override
+    public ZipFileSystem getFileSystem() {
+        return zfs;
+    }
+
+    @Override
+    public boolean isAbsolute() {
+        return path.length > 0 && path[0] == '/';
+    }
+
+    @Override
+    public ZipPath resolve(Path other) {
+        ZipPath o = checkPath(other);
+        if (o.path.length == 0)
+            return this;
+        if (o.isAbsolute() || this.path.length == 0)
+            return o;
+        return resolve(o.path);
+    }
+
+    // opath is normalized, just concat
+    private ZipPath resolve(byte[] opath) {
+        byte[] resolved;
+        byte[] tpath = this.path;
+        int tlen = tpath.length;
+        int olen = opath.length;
+        if (path[tlen - 1] == '/') {
+            resolved = new byte[tlen + olen];
+            System.arraycopy(tpath, 0, resolved, 0, tlen);
+            System.arraycopy(opath, 0, resolved, tlen, olen);
+        } else {
+            resolved = new byte[tlen + 1 + olen];
+            System.arraycopy(tpath, 0, resolved, 0, tlen);
+            resolved[tlen] = '/';
+            System.arraycopy(opath, 0, resolved, tlen + 1, olen);
+        }
+        return new ZipPath(zfs, resolved, true);
+    }
+
+    @Override
+    public Path resolveSibling(Path other) {
+        Objects.requireNonNull(other, "other");
+        Path parent = getParent();
+        return (parent == null) ? other : parent.resolve(other);
+    }
+
+    @Override
+    public boolean startsWith(Path other) {
+        Objects.requireNonNull(other, "other");
+        if (!(other instanceof ZipPath))
+            return false;
+        final ZipPath o = (ZipPath) other;
+        if (o.isAbsolute() != this.isAbsolute() ||
+                o.path.length > this.path.length)
+            return false;
+        int olast = o.path.length;
+        for (int i = 0; i < olast; i++) {
+            if (o.path[i] != this.path[i])
+                return false;
+        }
+        olast--;
+        return o.path.length == this.path.length ||
+                o.path[olast] == '/' ||
+                this.path[olast + 1] == '/';
+    }
+
+    @Override
+    public boolean endsWith(Path other) {
+        Objects.requireNonNull(other, "other");
+        if (!(other instanceof ZipPath))
+            return false;
+        final ZipPath o = (ZipPath) other;
+        int olast = o.path.length - 1;
+        if (olast > 0 && o.path[olast] == '/')
+            olast--;
+        int last = this.path.length - 1;
+        if (last > 0 && this.path[last] == '/')
+            last--;
+        if (olast == -1) // o.path.length == 0
+            return last == -1;
+        if ((o.isAbsolute() && (!this.isAbsolute() || olast != last)) ||
+                (last < olast))
+            return false;
+        for (; olast >= 0; olast--, last--) {
+            if (o.path[olast] != this.path[last])
+                return false;
+        }
+        return o.path[olast + 1] == '/' ||
+                last == -1 || this.path[last] == '/';
+    }
+
+    @Override
+    public ZipPath resolve(String other) {
+        byte[] opath = normalize(other);
+        if (opath.length == 0)
+            return this;
+        if (opath[0] == '/' || this.path.length == 0)
+            return new ZipPath(zfs, opath, true);
+        return resolve(opath);
+    }
+
+    @Override
+    public final Path resolveSibling(String other) {
+        return resolveSibling(zfs.getPath(other));
+    }
+
+    @Override
+    public final boolean startsWith(String other) {
+        return startsWith(zfs.getPath(other));
+    }
+
+    @Override
+    public final boolean endsWith(String other) {
+        return endsWith(zfs.getPath(other));
+    }
+
+    @Override
+    public Path normalize() {
+        byte[] resolved = getResolved();
+        if (resolved == path) // no change
+            return this;
+        return new ZipPath(zfs, resolved, true);
+    }
+
+    private ZipPath checkPath(Path path) {
+        Objects.requireNonNull(path, "path");
+        if (!(path instanceof ZipPath))
+            throw new ProviderMismatchException();
+        return (ZipPath) path;
+    }
+
+    // create offset list if not already created
+    private void initOffsets() {
+        if (offsets == null) {
+            int count, index;
+            // count names
+            count = 0;
+            index = 0;
+            if (path.length == 0) {
+                // empty path has one name
+                count = 1;
+            } else {
+                while (index < path.length) {
+                    byte c = path[index++];
+                    if (c != '/') {
+                        count++;
+                        while (index < path.length && path[index] != '/')
+                            index++;
+                    }
+                }
+            }
+            // populate offsets
+            int[] result = new int[count];
+            count = 0;
+            index = 0;
+            while (index < path.length) {
+                byte c = path[index];
+                if (c == '/') {
+                    index++;
+                } else {
+                    result[count++] = index++;
+                    while (index < path.length && path[index] != '/')
+                        index++;
+                }
+            }
+            synchronized (this) {
+                if (offsets == null)
+                    offsets = result;
+            }
+        }
+    }
+
+    // resolved path for locating zip entry inside the zip file,
+    // the result path does not contain ./ and .. components
+    private volatile byte[] resolved = null;
+
+    byte[] getResolvedPath() {
+        byte[] r = resolved;
+        if (r == null) {
+            if (isAbsolute())
+                r = getResolved();
+            else
+                r = toAbsolutePath().getResolvedPath();
+            resolved = r;
+        }
+        return resolved;
+    }
+
+    // removes redundant slashs, replace "\" to zip separator "/"
+    // and check for invalid characters
+    private byte[] normalize(byte[] path) {
+        int len = path.length;
+        if (len == 0)
+            return path;
+        byte prevC = 0;
+        for (int i = 0; i < len; i++) {
+            byte c = path[i];
+            if (c == '\\' || c == '\u0000')
+                return normalize(path, i);
+            if (c == (byte) '/' && prevC == '/')
+                return normalize(path, i - 1);
+            prevC = c;
+        }
+        if (len > 1 && prevC == '/') {
+            return Arrays.copyOf(path, len - 1);
+        }
+        return path;
+    }
+
+    private byte[] normalize(byte[] path, int off) {
+        byte[] to = new byte[path.length];
+        int n = 0;
+        while (n < off) {
+            to[n] = path[n];
+            n++;
+        }
+        int m = n;
+        byte prevC = 0;
+        while (n < path.length) {
+            byte c = path[n++];
+            if (c == (byte) '\\')
+                c = (byte) '/';
+            if (c == (byte) '/' && prevC == (byte) '/')
+                continue;
+            if (c == '\u0000')
+                throw new InvalidPathException(zfs.getString(path),
+                        "Path: nul character not allowed");
+            to[m++] = c;
+            prevC = c;
+        }
+        if (m > 1 && to[m - 1] == '/')
+            m--;
+        return (m == to.length) ? to : Arrays.copyOf(to, m);
+    }
+
+    // if zfs is NOT in utf8, normalize the path as "String"
+    // to avoid incorrectly normalizing byte '0x5c' (as '\')
+    // to '/'.
+    private byte[] normalize(String path) {
+        if (zfs.zc.isUTF8())
+            return normalize(zfs.getBytes(path));
+        int len = path.length();
+        if (len == 0)
+            return new byte[0];
+        char prevC = 0;
+        for (int i = 0; i < len; i++) {
+            char c = path.charAt(i);
+            if (c == '\\' || c == '\u0000')
+                return normalize(path, i, len);
+            if (c == '/' && prevC == '/')
+                return normalize(path, i - 1, len);
+            prevC = c;
+        }
+        if (len > 1 && prevC == '/')
+            path = path.substring(0, len - 1);
+        return zfs.getBytes(path);
+    }
+
+    private byte[] normalize(String path, int off, int len) {
+        StringBuilder to = new StringBuilder(len);
+        to.append(path, 0, off);
+        char prevC = 0;
+        while (off < len) {
+            char c = path.charAt(off++);
+            if (c == '\\')
+                c = '/';
+            if (c == '/' && prevC == '/')
+                continue;
+            if (c == '\u0000')
+                throw new InvalidPathException(path,
+                        "Path: nul character not allowed");
+            to.append(c);
+            prevC = c;
+        }
+        len = to.length();
+        if (len > 1 && prevC == '/')
+            to.delete(len - 1, len);
+        return zfs.getBytes(to.toString());
+    }
+
+    // Remove DotSlash(./) and resolve DotDot (..) components
+    private byte[] getResolved() {
+        for (int i = 0; i < path.length; i++) {
+            if (path[i] == (byte) '.' &&
+                    (i + 1 == path.length || path[i + 1] == '/')) {
+                return resolve0();
+            }
+        }
+        return path;
+    }
+
+    // TBD: performance, avoid initOffsets
+    private byte[] resolve0() {
+        byte[] to = new byte[path.length];
+        int nc = getNameCount();
+        int[] lastM = new int[nc];
+        int lastMOff = -1;
+        int m = 0;
+        for (int i = 0; i < nc; i++) {
+            int n = offsets[i];
+            int len = (i == offsets.length - 1) ? (path.length - n) : (offsets[i + 1] - n - 1);
+            if (len == 1 && path[n] == (byte) '.') {
+                if (m == 0 && path[0] == '/') // absolute path
+                    to[m++] = '/';
+                continue;
+            }
+            if (len == 2 && path[n] == '.' && path[n + 1] == '.') {
+                if (lastMOff >= 0) {
+                    m = lastM[lastMOff--]; // retreat
+                    continue;
+                }
+                if (path[0] == '/') { // "/../xyz" skip
+                    if (m == 0)
+                        to[m++] = '/';
+                } else { // "../xyz" -> "../xyz"
+                    if (m != 0 && to[m - 1] != '/')
+                        to[m++] = '/';
+                    while (len-- > 0)
+                        to[m++] = path[n++];
+                }
+                continue;
+            }
+            if (m == 0 && path[0] == '/' || // absolute path
+                    m != 0 && to[m - 1] != '/') { // not the first name
+                to[m++] = '/';
+            }
+            lastM[++lastMOff] = m;
+            while (len-- > 0)
+                to[m++] = path[n++];
+        }
+        if (m > 1 && to[m - 1] == '/')
+            m--;
+        return (m == to.length) ? to : Arrays.copyOf(to, m);
+    }
+
+    @Override
+    public String toString() {
+        return zfs.getString(path);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = hashcode;
+        if (h == 0)
+            hashcode = h = Arrays.hashCode(path);
+        return h;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof ZipPath &&
+                this.zfs == ((ZipPath) obj).zfs &&
+                compareTo((Path) obj) == 0;
+    }
+
+    @Override
+    public int compareTo(Path other) {
+        final ZipPath o = checkPath(other);
+        int len1 = this.path.length;
+        int len2 = o.path.length;
+
+        int n = Math.min(len1, len2);
+
+        int k = 0;
+        while (k < n) {
+            int c1 = this.path[k] & 0xff;
+            int c2 = o.path[k] & 0xff;
+            if (c1 != c2)
+                return c1 - c2;
+            k++;
+        }
+        return len1 - len2;
+    }
+
+    public WatchKey register(
+            WatchService watcher,
+            WatchEvent.Kind<?>[] events,
+            WatchEvent.Modifier... modifiers) {
+        if (watcher == null || events == null || modifiers == null) {
+            throw new NullPointerException();
+        }
+        // watcher must be associated with a different provider
+        throw new ProviderMismatchException();
+    }
+
+    @Override
+    public WatchKey register(WatchService watcher, WatchEvent.Kind<?>... events) {
+        return register(watcher, events, new WatchEvent.Modifier[0]);
+    }
+
+    @Override
+    public final File toFile() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        return new Iterator<>() {
+            private int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return (i < getNameCount());
+            }
+
+            @Override
+            public Path next() {
+                if (i < getNameCount()) {
+                    Path result = getName(i);
+                    i++;
+                    return result;
+                } else {
+                    throw new NoSuchElementException();
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new ReadOnlyFileSystemException();
+            }
+        };
+    }
+
+    /////////////////////////////////////////////////////////////////////
+
+    @SuppressWarnings("unchecked") // Cast to V
+    <V extends FileAttributeView> V getFileAttributeView(Class<V> type) {
+        if (type == null)
+            throw new NullPointerException();
+        if (type == BasicFileAttributeView.class)
+            return (V) new ZipFileAttributeView(this, false);
+        if (type == ZipFileAttributeView.class)
+            return (V) new ZipFileAttributeView(this, true);
+        if (zfs.supportPosix) {
+            if (type == PosixFileAttributeView.class)
+                return (V) new ZipPosixFileAttributeView(this, false);
+            if (type == FileOwnerAttributeView.class)
+                return (V) new ZipPosixFileAttributeView(this, true);
+        }
+        throw new UnsupportedOperationException("view <" + type + "> is not supported");
+    }
+
+    private ZipFileAttributeView getFileAttributeView(String type) {
+        if (type == null)
+            throw new NullPointerException();
+        if ("basic".equals(type))
+            return new ZipFileAttributeView(this, false);
+        if ("zip".equals(type))
+            return new ZipFileAttributeView(this, true);
+        if (zfs.supportPosix) {
+            if ("posix".equals(type))
+                return new ZipPosixFileAttributeView(this, false);
+            if ("owner".equals(type))
+                return new ZipPosixFileAttributeView(this, true);
+        }
+        throw new UnsupportedOperationException("view <" + type + "> is not supported");
+    }
+
+    void createDirectory(FileAttribute<?>... attrs)
+            throws IOException {
+        zfs.createDirectory(getResolvedPath(), attrs);
+    }
+
+    InputStream newInputStream(OpenOption... options) throws IOException {
+        if (options.length > 0) {
+            for (OpenOption opt : options) {
+                if (opt != READ)
+                    throw new UnsupportedOperationException("'" + opt + "' not allowed");
+            }
+        }
+        return zfs.newInputStream(getResolvedPath());
+    }
+
+    DirectoryStream<Path> newDirectoryStream(Filter<? super Path> filter)
+            throws IOException {
+        return new ZipDirectoryStream(this, filter);
+    }
+
+    void delete() throws IOException {
+        zfs.deleteFile(getResolvedPath(), true);
+    }
+
+    private void deleteIfExists() throws IOException {
+        zfs.deleteFile(getResolvedPath(), false);
+    }
+
+    ZipFileAttributes readAttributes() throws IOException {
+        ZipFileAttributes zfas = zfs.getFileAttributes(getResolvedPath());
+        if (zfas == null)
+            throw new NoSuchFileException(toString());
+        return zfas;
+    }
+
+    @SuppressWarnings("unchecked") // Cast to A
+    <A extends BasicFileAttributes> A readAttributes(Class<A> type) throws IOException {
+        // unconditionally support BasicFileAttributes and ZipFileAttributes
+        if (type == BasicFileAttributes.class || type == ZipFileAttributes.class) {
+            return (A) readAttributes();
+        }
+
+        // support PosixFileAttributes when activated
+        if (type == PosixFileAttributes.class && zfs.supportPosix) {
+            return (A) readAttributes();
+        }
+
+        throw new UnsupportedOperationException("Attributes of type " +
+                type.getName() + " not supported");
+    }
+
+    void setAttribute(String attribute, Object value, LinkOption... options)
+            throws IOException {
+        String type;
+        String attr;
+        int colonPos = attribute.indexOf(':');
+        if (colonPos == -1) {
+            type = "basic";
+            attr = attribute;
+        } else {
+            type = attribute.substring(0, colonPos++);
+            attr = attribute.substring(colonPos);
+        }
+        getFileAttributeView(type).setAttribute(attr, value);
+    }
+
+    void setTimes(FileTime mtime, FileTime atime, FileTime ctime)
+            throws IOException {
+        zfs.setTimes(getResolvedPath(), mtime, atime, ctime);
+    }
+
+    void setOwner(UserPrincipal owner) throws IOException {
+        zfs.setOwner(getResolvedPath(), owner);
+    }
+
+    void setPermissions(Set<PosixFilePermission> perms)
+            throws IOException {
+        zfs.setPermissions(getResolvedPath(), perms);
+    }
+
+    void setGroup(GroupPrincipal group) throws IOException {
+        zfs.setGroup(getResolvedPath(), group);
+    }
+
+    Map<String, Object> readAttributes(String attributes, LinkOption... options)
+            throws IOException {
+        String view;
+        String attrs;
+        int colonPos = attributes.indexOf(':');
+        if (colonPos == -1) {
+            view = "basic";
+            attrs = attributes;
+        } else {
+            view = attributes.substring(0, colonPos++);
+            attrs = attributes.substring(colonPos);
+        }
+        return getFileAttributeView(view).readAttributes(attrs);
+    }
+
+    FileStore getFileStore() throws IOException {
+        // each ZipFileSystem only has one root (as requested for now)
+        if (exists())
+            return zfs.getFileStore(this);
+        throw new NoSuchFileException(zfs.getString(path));
+    }
+
+    boolean isSameFile(Path other) throws IOException {
+        if (this.equals(other))
+            return true;
+        if (other == null ||
+                this.getFileSystem() != other.getFileSystem())
+            return false;
+        this.checkAccess();
+        ((ZipPath) other).checkAccess();
+        return Arrays.equals(this.getResolvedPath(),
+                ((ZipPath) other).getResolvedPath());
+    }
+
+    SeekableByteChannel newByteChannel(Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs)
+            throws IOException {
+        return zfs.newByteChannel(getResolvedPath(), options, attrs);
+    }
+
+    FileChannel newFileChannel(Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs)
+            throws IOException {
+        return zfs.newFileChannel(getResolvedPath(), options, attrs);
+    }
+
+    void checkAccess(AccessMode... modes) throws IOException {
+        boolean w = false;
+        boolean x = false;
+        for (AccessMode mode : modes) {
+            switch (mode) {
+                case READ:
+                    break;
+                case WRITE:
+                    w = true;
+                    break;
+                case EXECUTE:
+                    x = true;
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+        zfs.checkAccess(getResolvedPath());
+        if ((w && zfs.isReadOnly()) || x) {
+            throw new AccessDeniedException(toString());
+        }
+    }
+
+    private boolean exists() {
+        return zfs.exists(getResolvedPath());
+    }
+
+    OutputStream newOutputStream(OpenOption... options) throws IOException {
+        if (options.length == 0)
+            return zfs.newOutputStream(getResolvedPath(),
+                    CREATE, TRUNCATE_EXISTING, WRITE);
+        return zfs.newOutputStream(getResolvedPath(), options);
+    }
+
+    void move(ZipPath target, CopyOption... options)
+            throws IOException {
+        if (Files.isSameFile(this.zfs.getZipFile(), target.zfs.getZipFile())) {
+            zfs.copyFile(true,
+                    getResolvedPath(), target.getResolvedPath(),
+                    options);
+        } else {
+            copyToTarget(target, options);
+            delete();
+        }
+    }
+
+    void copy(ZipPath target, CopyOption... options)
+            throws IOException {
+        if (Files.isSameFile(this.zfs.getZipFile(), target.zfs.getZipFile()))
+            zfs.copyFile(false,
+                    getResolvedPath(), target.getResolvedPath(),
+                    options);
+        else
+            copyToTarget(target, options);
+    }
+
+    private void copyToTarget(ZipPath target, CopyOption... options)
+            throws IOException {
+        boolean replaceExisting = false;
+        boolean copyAttrs = false;
+        for (CopyOption opt : options) {
+            if (opt == REPLACE_EXISTING)
+                replaceExisting = true;
+            else if (opt == COPY_ATTRIBUTES)
+                copyAttrs = true;
+        }
+        // attributes of source file
+        ZipFileAttributes zfas = readAttributes();
+        // check if target exists
+        boolean exists;
+        if (replaceExisting) {
+            try {
+                target.deleteIfExists();
+                exists = false;
+            } catch (DirectoryNotEmptyException x) {
+                exists = true;
+            }
+        } else {
+            exists = target.exists();
+        }
+        if (exists)
+            throw new FileAlreadyExistsException(target.toString());
+
+        if (zfas.isDirectory()) {
+            // create directory or file
+            target.createDirectory();
+        } else {
+            try (InputStream is = zfs.newInputStream(getResolvedPath());
+                    OutputStream os = target.newOutputStream()) {
+                is.transferTo(os);
+            }
+        }
+        if (copyAttrs) {
+            ZipFileAttributeView view = target.getFileAttributeView(ZipFileAttributeView.class);
+            try {
+                view.setTimes(zfas.lastModifiedTime(),
+                        zfas.lastAccessTime(),
+                        zfas.creationTime());
+                // copy permissions
+                view.setPermissions(zfas.storedPermissions().orElse(null));
+            } catch (IOException x) {
+                // rollback?
+                try {
+                    target.delete();
+                } catch (IOException ignore) {
+                }
+                throw x;
+            }
+        }
+    }
+
+    private static int decode(char c) {
+        if ((c >= '0') && (c <= '9'))
+            return c - '0';
+        if ((c >= 'a') && (c <= 'f'))
+            return c - 'a' + 10;
+        if ((c >= 'A') && (c <= 'F'))
+            return c - 'A' + 10;
+        assert false;
+        return -1;
+    }
+
+    // to avoid double escape
+    private static String decodeUri(String s) {
+        if (s == null)
+            return null;
+        int n = s.length();
+        if (n == 0)
+            return s;
+        if (s.indexOf('%') < 0)
+            return s;
+
+        StringBuilder sb = new StringBuilder(n);
+        byte[] bb = new byte[n];
+        boolean betweenBrackets = false;
+
+        for (int i = 0; i < n;) {
+            char c = s.charAt(i);
+            if (c == '[') {
+                betweenBrackets = true;
+            } else if (betweenBrackets && c == ']') {
+                betweenBrackets = false;
+            }
+            if (c != '%' || betweenBrackets) {
+                sb.append(c);
+                i++;
+                continue;
+            }
+            int nb = 0;
+            while (c == '%') {
+                assert (n - i >= 2);
+                bb[nb++] = (byte) (((decode(s.charAt(++i)) & 0xf) << 4) |
+                        (decode(s.charAt(++i)) & 0xf));
+                if (++i >= n) {
+                    break;
+                }
+                c = s.charAt(i);
+            }
+            sb.append(new String(bb, 0, nb, UTF_8));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipPosixFileAttributeView.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipPosixFileAttributeView.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.UserPrincipal;
+
+/**
+ * The zip file system attribute view with POSIX support.
+ */
+class ZipPosixFileAttributeView extends ZipFileAttributeView implements PosixFileAttributeView {
+    private final boolean isOwnerView;
+
+    ZipPosixFileAttributeView(ZipPath path, boolean owner) {
+        super(path, true);
+        this.isOwnerView = owner;
+    }
+
+    @Override
+    public String name() {
+        return isOwnerView ? "owner" : "posix";
+    }
+
+    @Override
+    public PosixFileAttributes readAttributes() throws IOException {
+        return (PosixFileAttributes) path.readAttributes();
+    }
+
+    @Override
+    public UserPrincipal getOwner() throws IOException {
+        return readAttributes().owner();
+    }
+
+    @Override
+    public void setOwner(UserPrincipal owner) throws IOException {
+        path.setOwner(owner);
+    }
+
+    @Override
+    public void setGroup(GroupPrincipal group) throws IOException {
+        path.setGroup(group);
+    }
+
+    @Override
+    Object attribute(AttrID id, ZipFileAttributes zfas) {
+        PosixFileAttributes pzfas = (PosixFileAttributes) zfas;
+        switch (id) {
+            case owner:
+                return pzfas.owner();
+            case group:
+                return pzfas.group();
+            case permissions:
+                if (!isOwnerView) {
+                    return pzfas.permissions();
+                } else {
+                    return super.attribute(id, zfas);
+                }
+            default:
+                return super.attribute(id, zfas);
+        }
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/zipfs/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/zipfs/ZipUtils.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package io.quarkus.fs.util.zipfs;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.attribute.PosixFilePermission;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * @author Xueming Shen
+ */
+class ZipUtils {
+
+    /**
+     * The bit flag used to specify read permission by the owner.
+     */
+    static final int POSIX_USER_READ = 0400;
+
+    /**
+     * The bit flag used to specify write permission by the owner.
+     */
+    static final int POSIX_USER_WRITE = 0200;
+
+    /**
+     * The bit flag used to specify execute permission by the owner.
+     */
+    static final int POSIX_USER_EXECUTE = 0100;
+
+    /**
+     * The bit flag used to specify read permission by the group.
+     */
+    static final int POSIX_GROUP_READ = 040;
+
+    /**
+     * The bit flag used to specify write permission by the group.
+     */
+    static final int POSIX_GROUP_WRITE = 020;
+
+    /**
+     * The bit flag used to specify execute permission by the group.
+     */
+    static final int POSIX_GROUP_EXECUTE = 010;
+
+    /**
+     * The bit flag used to specify read permission by others.
+     */
+    static final int POSIX_OTHER_READ = 04;
+
+    /**
+     * The bit flag used to specify write permission by others.
+     */
+    static final int POSIX_OTHER_WRITE = 02;
+
+    /**
+     * The bit flag used to specify execute permission by others.
+     */
+    static final int POSIX_OTHER_EXECUTE = 01;
+
+    /**
+     * Convert a {@link PosixFilePermission} object into the appropriate bit
+     * flag.
+     *
+     * @param perm The {@link PosixFilePermission} object.
+     * @return The bit flag as int.
+     */
+    static int permToFlag(PosixFilePermission perm) {
+        switch (perm) {
+            case OWNER_READ:
+                return POSIX_USER_READ;
+            case OWNER_WRITE:
+                return POSIX_USER_WRITE;
+            case OWNER_EXECUTE:
+                return POSIX_USER_EXECUTE;
+            case GROUP_READ:
+                return POSIX_GROUP_READ;
+            case GROUP_WRITE:
+                return POSIX_GROUP_WRITE;
+            case GROUP_EXECUTE:
+                return POSIX_GROUP_EXECUTE;
+            case OTHERS_READ:
+                return POSIX_OTHER_READ;
+            case OTHERS_WRITE:
+                return POSIX_OTHER_WRITE;
+            case OTHERS_EXECUTE:
+                return POSIX_OTHER_EXECUTE;
+            default:
+                return 0;
+        }
+    }
+
+    /**
+     * Converts a set of {@link PosixFilePermission}s into an int value where
+     * the according bits are set.
+     *
+     * @param perms A Set of {@link PosixFilePermission} objects.
+     *
+     * @return A bit mask representing the input Set.
+     */
+    static int permsToFlags(Set<PosixFilePermission> perms) {
+        if (perms == null) {
+            return -1;
+        }
+        int flags = 0;
+        for (PosixFilePermission perm : perms) {
+            flags |= permToFlag(perm);
+        }
+        return flags;
+    }
+
+    /*
+     * Writes a 16-bit short to the output stream in little-endian byte order.
+     */
+    public static void writeShort(OutputStream os, int v) throws IOException {
+        os.write(v & 0xff);
+        os.write((v >>> 8) & 0xff);
+    }
+
+    /*
+     * Writes a 32-bit int to the output stream in little-endian byte order.
+     */
+    public static void writeInt(OutputStream os, long v) throws IOException {
+        os.write((int) (v & 0xff));
+        os.write((int) ((v >>> 8) & 0xff));
+        os.write((int) ((v >>> 16) & 0xff));
+        os.write((int) ((v >>> 24) & 0xff));
+    }
+
+    /*
+     * Writes a 64-bit int to the output stream in little-endian byte order.
+     */
+    public static void writeLong(OutputStream os, long v) throws IOException {
+        os.write((int) (v & 0xff));
+        os.write((int) ((v >>> 8) & 0xff));
+        os.write((int) ((v >>> 16) & 0xff));
+        os.write((int) ((v >>> 24) & 0xff));
+        os.write((int) ((v >>> 32) & 0xff));
+        os.write((int) ((v >>> 40) & 0xff));
+        os.write((int) ((v >>> 48) & 0xff));
+        os.write((int) ((v >>> 56) & 0xff));
+    }
+
+    /*
+     * Writes an array of bytes to the output stream.
+     */
+    public static void writeBytes(OutputStream os, byte[] b)
+            throws IOException {
+        os.write(b, 0, b.length);
+    }
+
+    /*
+     * Writes an array of bytes to the output stream.
+     */
+    public static void writeBytes(OutputStream os, byte[] b, int off, int len)
+            throws IOException {
+        os.write(b, off, len);
+    }
+
+    /*
+     * Append a slash at the end, if it does not have one yet
+     */
+    public static byte[] toDirectoryPath(byte[] dir) {
+        if (dir.length != 0 && dir[dir.length - 1] != '/') {
+            dir = Arrays.copyOf(dir, dir.length + 1);
+            dir[dir.length - 1] = '/';
+        }
+        return dir;
+    }
+
+    /*
+     * Converts DOS time to Java time (number of milliseconds since epoch).
+     */
+    public static long dosToJavaTime(long dtime) {
+        int year = (int) (((dtime >> 25) & 0x7f) + 1980);
+        int month = (int) ((dtime >> 21) & 0x0f);
+        int day = (int) ((dtime >> 16) & 0x1f);
+        int hour = (int) ((dtime >> 11) & 0x1f);
+        int minute = (int) ((dtime >> 5) & 0x3f);
+        int second = (int) ((dtime << 1) & 0x3e);
+
+        if (month > 0 && month < 13 && day > 0 && hour < 24 && minute < 60 && second < 60) {
+            try {
+                LocalDateTime ldt = LocalDateTime.of(year, month, day, hour, minute, second);
+                return TimeUnit.MILLISECONDS.convert(ldt.toEpochSecond(
+                        ZoneId.systemDefault().getRules().getOffset(ldt)), TimeUnit.SECONDS);
+            } catch (DateTimeException dte) {
+                // ignore
+            }
+        }
+        return overflowDosToJavaTime(year, month, day, hour, minute, second);
+    }
+
+    /*
+     * Deal with corner cases where an arguably mal-formed DOS time is used
+     */
+    @SuppressWarnings("deprecation") // Use of Date constructor
+    private static long overflowDosToJavaTime(int year, int month, int day,
+            int hour, int minute, int second) {
+        return new Date(year - 1900, month - 1, day, hour, minute, second).getTime();
+    }
+
+    /*
+     * Converts Java time to DOS time.
+     */
+    public static long javaToDosTime(long time) {
+        Instant instant = Instant.ofEpochMilli(time);
+        LocalDateTime ldt = LocalDateTime.ofInstant(
+                instant, ZoneId.systemDefault());
+        int year = ldt.getYear() - 1980;
+        if (year < 0) {
+            return (1 << 21) | (1 << 16);
+        }
+        return (year << 25 |
+                ldt.getMonthValue() << 21 |
+                ldt.getDayOfMonth() << 16 |
+                ldt.getHour() << 11 |
+                ldt.getMinute() << 5 |
+                ldt.getSecond() >> 1) & 0xffffffffL;
+    }
+
+    // used to adjust values between Windows and java epoch
+    private static final long WINDOWS_EPOCH_IN_MICROSECONDS = -11644473600000000L;
+
+    public static final long winToJavaTime(long wtime) {
+        return TimeUnit.MILLISECONDS.convert(
+                wtime / 10 + WINDOWS_EPOCH_IN_MICROSECONDS, TimeUnit.MICROSECONDS);
+    }
+
+    public static final long javaToWinTime(long time) {
+        return (TimeUnit.MICROSECONDS.convert(time, TimeUnit.MILLISECONDS)
+                - WINDOWS_EPOCH_IN_MICROSECONDS) * 10;
+    }
+
+    public static final long unixToJavaTime(long utime) {
+        return TimeUnit.MILLISECONDS.convert(utime, TimeUnit.SECONDS);
+    }
+
+    public static final long javaToUnixTime(long time) {
+        return TimeUnit.SECONDS.convert(time, TimeUnit.MILLISECONDS);
+    }
+
+    private static final String regexMetaChars = ".^$+{[]|()";
+    private static final String globMetaChars = "\\*?[{";
+
+    private static boolean isRegexMeta(char c) {
+        return regexMetaChars.indexOf(c) != -1;
+    }
+
+    private static boolean isGlobMeta(char c) {
+        return globMetaChars.indexOf(c) != -1;
+    }
+
+    private static char EOL = 0; //TBD
+
+    private static char next(String glob, int i) {
+        if (i < glob.length()) {
+            return glob.charAt(i);
+        }
+        return EOL;
+    }
+
+    /*
+     * Creates a regex pattern from the given glob expression.
+     *
+     * @throws PatternSyntaxException
+     */
+    public static String toRegexPattern(String globPattern) {
+        boolean inGroup = false;
+        StringBuilder regex = new StringBuilder("^");
+
+        int i = 0;
+        while (i < globPattern.length()) {
+            char c = globPattern.charAt(i++);
+            switch (c) {
+                case '\\':
+                    // escape special characters
+                    if (i == globPattern.length()) {
+                        throw new PatternSyntaxException("No character to escape",
+                                globPattern, i - 1);
+                    }
+                    char next = globPattern.charAt(i++);
+                    if (isGlobMeta(next) || isRegexMeta(next)) {
+                        regex.append('\\');
+                    }
+                    regex.append(next);
+                    break;
+                case '/':
+                    regex.append(c);
+                    break;
+                case '[':
+                    // don't match name separator in class
+                    regex.append("[[^/]&&[");
+                    if (next(globPattern, i) == '^') {
+                        // escape the regex negation char if it appears
+                        regex.append("\\^");
+                        i++;
+                    } else {
+                        // negation
+                        if (next(globPattern, i) == '!') {
+                            regex.append('^');
+                            i++;
+                        }
+                        // hyphen allowed at start
+                        if (next(globPattern, i) == '-') {
+                            regex.append('-');
+                            i++;
+                        }
+                    }
+                    boolean hasRangeStart = false;
+                    char last = 0;
+                    while (i < globPattern.length()) {
+                        c = globPattern.charAt(i++);
+                        if (c == ']') {
+                            break;
+                        }
+                        if (c == '/') {
+                            throw new PatternSyntaxException("Explicit 'name separator' in class",
+                                    globPattern, i - 1);
+                        }
+                        // TBD: how to specify ']' in a class?
+                        if (c == '\\' || c == '[' ||
+                                c == '&' && next(globPattern, i) == '&') {
+                            // escape '\', '[' or "&&" for regex class
+                            regex.append('\\');
+                        }
+                        regex.append(c);
+
+                        if (c == '-') {
+                            if (!hasRangeStart) {
+                                throw new PatternSyntaxException("Invalid range",
+                                        globPattern, i - 1);
+                            }
+                            if ((c = next(globPattern, i++)) == EOL || c == ']') {
+                                break;
+                            }
+                            if (c < last) {
+                                throw new PatternSyntaxException("Invalid range",
+                                        globPattern, i - 3);
+                            }
+                            regex.append(c);
+                            hasRangeStart = false;
+                        } else {
+                            hasRangeStart = true;
+                            last = c;
+                        }
+                    }
+                    if (c != ']') {
+                        throw new PatternSyntaxException("Missing ']", globPattern, i - 1);
+                    }
+                    regex.append("]]");
+                    break;
+                case '{':
+                    if (inGroup) {
+                        throw new PatternSyntaxException("Cannot nest groups",
+                                globPattern, i - 1);
+                    }
+                    regex.append("(?:(?:");
+                    inGroup = true;
+                    break;
+                case '}':
+                    if (inGroup) {
+                        regex.append("))");
+                        inGroup = false;
+                    } else {
+                        regex.append('}');
+                    }
+                    break;
+                case ',':
+                    if (inGroup) {
+                        regex.append(")|(?:");
+                    } else {
+                        regex.append(',');
+                    }
+                    break;
+                case '*':
+                    if (next(globPattern, i) == '*') {
+                        // crosses directory boundaries
+                        regex.append(".*");
+                        i++;
+                    } else {
+                        // within directory boundary
+                        regex.append("[^/]*");
+                    }
+                    break;
+                case '?':
+                    regex.append("[^/]");
+                    break;
+                default:
+                    if (isRegexMeta(c)) {
+                        regex.append('\\');
+                    }
+                    regex.append(c);
+            }
+        }
+        if (inGroup) {
+            throw new PatternSyntaxException("Missing '}", globPattern, i - 1);
+        }
+        return regex.append('$').toString();
+    }
+}


### PR DESCRIPTION
This prevents doing a bit of io each time a ZFS is opened. Most zips are opened as read only (e.g. to read content during bootstrap), but never written to.

The ZFS classes are copied from jdk 17.
As additional side effect, the changes regarding defaultOwner / defaultGroup are also made available to jdk 11 users.

On quarkus main (e866c8e), this saves about 40ms.
For https://github.com/quarkusio/quarkus/pull/22336, this saves about 200ms.

related to #21552

Questions:
* Licensing is unclear. JDK source is in GPLv2, while this library is using Apache. Is copying GPL source into a Apache licensed program ok? I don't believe so.
```
Despite our best efforts, the FSF has never considered the Apache License to be compatible with GPL version 2, citing the patent termination and indemnification provisions as restrictions not present in the older GPL license.
```

We could relicense this library as gplv2. WDYT?

* I Haven't done a full Quarkus CI run (and no jdk11 runs), I have no confidence in this change whatsoever :)