### PR TITLE
Prevent writeability checks on the file system path when not needed

### DIFF
--- a/src/main/java/io/quarkus/fs/util/base/DelegatingFileSystem.java
+++ b/src/main/java/io/quarkus/fs/util/base/DelegatingFileSystem.java
@@ -1,0 +1,106 @@
+package io.quarkus.fs.util.base;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Base Implementation of a FileSystem delegating most operations to another FileSystem.
+ */
+public abstract class DelegatingFileSystem extends FileSystem {
+    protected final FileSystem delegate;
+
+    /**
+     * @param delegate the FileSystem to delegate to. May not be null.
+     */
+    public DelegatingFileSystem(FileSystem delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return delegate.provider();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return delegate.isReadOnly();
+    }
+
+    @Override
+    public String getSeparator() {
+        return delegate.getSeparator();
+    }
+
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return delegate.getRootDirectories();
+    }
+
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return delegate.getFileStores();
+    }
+
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        return delegate.supportedFileAttributeViews();
+    }
+
+    @Override
+    public Path getPath(String first, String... more) {
+        return delegate.getPath(first, more);
+    }
+
+    @Override
+    public PathMatcher getPathMatcher(String syntaxAndPattern) {
+        return delegate.getPathMatcher(syntaxAndPattern);
+    }
+
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService() {
+        return delegate.getUserPrincipalLookupService();
+    }
+
+    @Override
+    public WatchService newWatchService() throws IOException {
+        return delegate.newWatchService();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DelegatingFileSystem that = (DelegatingFileSystem) o;
+        return Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/base/DelegatingFileSystemProvider.java
+++ b/src/main/java/io/quarkus/fs/util/base/DelegatingFileSystemProvider.java
@@ -1,0 +1,194 @@
+package io.quarkus.fs.util.base;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Base Implementation of a FileSystemProvider delegating most operations to another FileSystemProvider.
+ */
+public abstract class DelegatingFileSystemProvider extends FileSystemProvider {
+    protected final FileSystemProvider delegate;
+
+    /**
+     *
+     * @param delegate the FileSystemProvider to delegate to. May not be null
+     */
+    protected DelegatingFileSystemProvider(FileSystemProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getScheme() {
+        return delegate.getScheme();
+    }
+
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+        return delegate.newFileSystem(uri, env);
+    }
+
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        return delegate.getFileSystem(uri);
+    }
+
+    @Override
+    public Path getPath(URI uri) {
+        return delegate.getPath(uri);
+    }
+
+    @Override
+    public FileSystem newFileSystem(Path path, Map<String, ?> env) throws IOException {
+        return delegate.newFileSystem(DelegatingPath.unwrap(path), env);
+    }
+
+    @Override
+    public InputStream newInputStream(Path path, OpenOption... options) throws IOException {
+        return delegate.newInputStream(DelegatingPath.unwrap(path), options);
+    }
+
+    @Override
+    public OutputStream newOutputStream(Path path, OpenOption... options) throws IOException {
+        return delegate.newOutputStream(DelegatingPath.unwrap(path), options);
+    }
+
+    @Override
+    public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
+            throws IOException {
+        return delegate.newFileChannel(DelegatingPath.unwrap(path), options, attrs);
+    }
+
+    @Override
+    public AsynchronousFileChannel newAsynchronousFileChannel(Path path, Set<? extends OpenOption> options,
+            ExecutorService executor, FileAttribute<?>... attrs) throws IOException {
+        return delegate.newAsynchronousFileChannel(DelegatingPath.unwrap(path), options, executor, attrs);
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
+            throws IOException {
+        return delegate.newByteChannel(DelegatingPath.unwrap(path), options, attrs);
+    }
+
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException {
+        return delegate.newDirectoryStream(DelegatingPath.unwrap(dir), filter);
+    }
+
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+        delegate.createDirectory(DelegatingPath.unwrap(dir), attrs);
+    }
+
+    @Override
+    public void createSymbolicLink(Path link, Path target, FileAttribute<?>... attrs) throws IOException {
+        delegate.createSymbolicLink(DelegatingPath.unwrap(link), DelegatingPath.unwrap(target), attrs);
+    }
+
+    @Override
+    public void createLink(Path link, Path existing) throws IOException {
+        delegate.createLink(DelegatingPath.unwrap(link), DelegatingPath.unwrap(existing));
+    }
+
+    @Override
+    public void delete(Path path) throws IOException {
+        delegate.delete(DelegatingPath.unwrap(path));
+    }
+
+    @Override
+    public boolean deleteIfExists(Path path) throws IOException {
+        return delegate.deleteIfExists(DelegatingPath.unwrap(path));
+    }
+
+    @Override
+    public Path readSymbolicLink(Path link) throws IOException {
+        return delegate.readSymbolicLink(link);
+    }
+
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        delegate.copy(DelegatingPath.unwrap(source), DelegatingPath.unwrap(target), options);
+    }
+
+    @Override
+    public void move(Path source, Path target, CopyOption... options) throws IOException {
+        delegate.move(DelegatingPath.unwrap(source), DelegatingPath.unwrap(target), options);
+    }
+
+    @Override
+    public boolean isSameFile(Path path, Path path2) throws IOException {
+        return delegate.isSameFile(DelegatingPath.unwrap(path), DelegatingPath.unwrap(path2));
+    }
+
+    @Override
+    public boolean isHidden(Path path) throws IOException {
+        return delegate.isHidden(DelegatingPath.unwrap(path));
+    }
+
+    @Override
+    public FileStore getFileStore(Path path) throws IOException {
+        return delegate.getFileStore(DelegatingPath.unwrap(path));
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        delegate.checkAccess(DelegatingPath.unwrap(path), modes);
+    }
+
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
+        return delegate.getFileAttributeView(DelegatingPath.unwrap(path), type, options);
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options)
+            throws IOException {
+        return delegate.readAttributes(DelegatingPath.unwrap(path), type, options);
+    }
+
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) throws IOException {
+        return delegate.readAttributes(DelegatingPath.unwrap(path), attributes, options);
+    }
+
+    @Override
+    public void setAttribute(Path path, String attribute, Object value, LinkOption... options) throws IOException {
+        delegate.setAttribute(DelegatingPath.unwrap(path), attribute, value, options);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DelegatingFileSystemProvider that = (DelegatingFileSystemProvider) o;
+        return Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/base/DelegatingPath.java
+++ b/src/main/java/io/quarkus/fs/util/base/DelegatingPath.java
@@ -1,0 +1,211 @@
+package io.quarkus.fs.util.base;
+
+import io.quarkus.fs.util.sysfs.PathWrapper;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * Base Implementation of a Path delegating most operations to another Path.
+ */
+public abstract class DelegatingPath implements Path {
+    protected final Path delegate;
+
+    /**
+     *
+     * @param delegate the Path to delegate to. May not be null.
+     */
+    protected DelegatingPath(Path delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Helper method to unwrap a {@link DelegatingPath} to the specific Path implementation. Some providers do internal checks
+     * to make
+     * sure that a Path is compatible with a FS. E.g. a WindowsFileSystem only works with WindowsPaths
+     *
+     * @param path
+     * @return unwrapped path, or the original one if not an instance of DelegatingPath
+     */
+    public static Path unwrap(Path path) {
+        if (path instanceof PathWrapper) {
+            return ((PathWrapper) path).getDelegate();
+        }
+        return path;
+    }
+
+    public Path getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean startsWith(String other) {
+        return delegate.startsWith(other);
+    }
+
+    @Override
+    public boolean endsWith(String other) {
+        return delegate.endsWith(other);
+    }
+
+    @Override
+    public Path resolve(String other) {
+        return delegate.resolve(other);
+    }
+
+    @Override
+    public Path resolveSibling(Path other) {
+        return delegate.resolveSibling(other);
+    }
+
+    @Override
+    public Path resolveSibling(String other) {
+        return delegate.resolveSibling(other);
+    }
+
+    @Override
+    public File toFile() {
+        return delegate.toFile();
+    }
+
+    @Override
+    public WatchKey register(WatchService watcher, WatchEvent.Kind<?>... events) throws IOException {
+        return delegate.register(watcher, events);
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return delegate.getFileSystem();
+    }
+
+    @Override
+    public boolean isAbsolute() {
+        return delegate.isAbsolute();
+    }
+
+    @Override
+    public Path getRoot() {
+        return delegate.getRoot();
+    }
+
+    @Override
+    public Path getFileName() {
+        return delegate.getFileName();
+    }
+
+    @Override
+    public Path getParent() {
+        return delegate.getParent();
+    }
+
+    @Override
+    public int getNameCount() {
+        return delegate.getNameCount();
+    }
+
+    @Override
+    public Path getName(int index) {
+        return delegate.getName(index);
+    }
+
+    @Override
+    public Path subpath(int beginIndex, int endIndex) {
+        return delegate.subpath(beginIndex, endIndex);
+    }
+
+    @Override
+    public boolean startsWith(Path other) {
+        return delegate.startsWith(other);
+    }
+
+    @Override
+    public boolean endsWith(Path other) {
+        return delegate.endsWith(other);
+    }
+
+    @Override
+    public Path normalize() {
+        return delegate.normalize();
+    }
+
+    @Override
+    public Path resolve(Path other) {
+        return delegate.resolve(other);
+    }
+
+    @Override
+    public Path relativize(Path other) {
+        return delegate.relativize(other);
+    }
+
+    @Override
+    public URI toUri() {
+        return delegate.toUri();
+    }
+
+    @Override
+    public Path toAbsolutePath() {
+        return delegate.toAbsolutePath();
+    }
+
+    @Override
+    public Path toRealPath(LinkOption... options) throws IOException {
+        return delegate.toRealPath(options);
+    }
+
+    @Override
+    public WatchKey register(WatchService watcher, WatchEvent.Kind<?>[] events, WatchEvent.Modifier... modifiers)
+            throws IOException {
+        return delegate.register(watcher, events, modifiers);
+    }
+
+    @Override
+    public int compareTo(Path other) {
+        return delegate.compareTo(other);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public void forEach(Consumer<? super Path> action) {
+        delegate.forEach(action);
+    }
+
+    @Override
+    public Spliterator<Path> spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DelegatingPath that = (DelegatingPath) o;
+        return Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/sysfs/ConfigurableFileSystemProviderWrapper.java
+++ b/src/main/java/io/quarkus/fs/util/sysfs/ConfigurableFileSystemProviderWrapper.java
@@ -1,0 +1,51 @@
+package io.quarkus.fs.util.sysfs;
+
+import io.quarkus.fs.util.base.DelegatingFileSystemProvider;
+import io.quarkus.fs.util.base.DelegatingPath;
+import java.io.IOException;
+import java.nio.file.AccessMode;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Configurable File System Provider, which delegates all tasks to a delegate FSP, except for access mode checks.
+ */
+public class ConfigurableFileSystemProviderWrapper extends DelegatingFileSystemProvider {
+    private final Set<AccessMode> allowedAccessModes;
+
+    /**
+     *
+     * @param delegate the FileSystemProvider to delegate to. May not be null
+     * @param allowedAccessModes The access modes which should be allowed by default. They given path won't be checked for
+     *        these. May be null.
+     */
+    public ConfigurableFileSystemProviderWrapper(FileSystemProvider delegate, Set<AccessMode> allowedAccessModes) {
+        super(delegate);
+        this.allowedAccessModes = Objects.requireNonNullElse(allowedAccessModes, Collections.emptySet());
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        if (modes.length > 0 && !allowedAccessModes.isEmpty()) {
+            List<AccessMode> accessModes = new ArrayList<>(3);
+            for (AccessMode mode : modes) {
+                if (!allowedAccessModes.contains(mode)) {
+                    accessModes.add(mode);
+                }
+            }
+
+            if (accessModes.isEmpty()) {
+                return;
+            }
+
+            modes = accessModes.toArray(new AccessMode[0]);
+        }
+
+        delegate.checkAccess(DelegatingPath.unwrap(path), modes);
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/sysfs/FileSystemWrapper.java
+++ b/src/main/java/io/quarkus/fs/util/sysfs/FileSystemWrapper.java
@@ -1,0 +1,25 @@
+package io.quarkus.fs.util.sysfs;
+
+import io.quarkus.fs.util.base.DelegatingFileSystem;
+import java.nio.file.FileSystem;
+import java.nio.file.spi.FileSystemProvider;
+
+public class FileSystemWrapper extends DelegatingFileSystem {
+    private final FileSystemProvider fileSystemProvider;
+
+    /**
+     *
+     * @param delegate the FileSystem to delegate to. May not be null.
+     * @param fileSystemProvider any calls to {@link #provider()} will return this provider instead of the delegates ones.
+     *        May not be null.
+     */
+    public FileSystemWrapper(FileSystem delegate, FileSystemProvider fileSystemProvider) {
+        super(delegate);
+        this.fileSystemProvider = fileSystemProvider;
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return fileSystemProvider;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/sysfs/PathWrapper.java
+++ b/src/main/java/io/quarkus/fs/util/sysfs/PathWrapper.java
@@ -1,0 +1,25 @@
+package io.quarkus.fs.util.sysfs;
+
+import io.quarkus.fs.util.base.DelegatingPath;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+
+public class PathWrapper extends DelegatingPath {
+    private final FileSystem fileSystem;
+
+    /**
+     *
+     * @param delegate the Path to delegate to. May not be null.
+     * @param fileSystem any calls to {@link #getFileSystem()} ()} will return this fileSystem instead of the delegates ones.
+     *        May not be null.
+     */
+    public PathWrapper(Path delegate, FileSystem fileSystem) {
+        super(delegate);
+        this.fileSystem = fileSystem;
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+}

--- a/src/test/java/io/quarkus/fs/util/sysfs/ConfigurableFileSystemProviderWrapperTest.java
+++ b/src/test/java/io/quarkus/fs/util/sysfs/ConfigurableFileSystemProviderWrapperTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.fs.util.sysfs;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.quarkus.fs.util.base.DelegatingFileSystemProvider;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ConfigurableFileSystemProviderWrapperTest {
+    @Test
+    void testAllowedAccessModes() throws IOException {
+        Path tempFile = File.createTempFile("testAllowedAccessModes", "quarkus").toPath();
+        DenyAllAccessModesFileSystemProvider denyAllFsp = new DenyAllAccessModesFileSystemProvider(
+                tempFile.getFileSystem().provider());
+
+        ConfigurableFileSystemProviderWrapper configurableFsp = new ConfigurableFileSystemProviderWrapper(denyAllFsp,
+                Set.of(AccessMode.WRITE, AccessMode.EXECUTE));
+
+        assertThrows(AccessDeniedException.class, () -> {
+            configurableFsp.checkAccess(tempFile);
+        });
+        assertThrows(AccessDeniedException.class, () -> {
+            configurableFsp.checkAccess(tempFile, AccessMode.READ);
+        });
+
+        assertDoesNotThrow(() -> {
+            configurableFsp.checkAccess(tempFile, AccessMode.WRITE);
+            configurableFsp.checkAccess(tempFile, AccessMode.EXECUTE);
+        });
+    }
+
+    private class DenyAllAccessModesFileSystemProvider extends DelegatingFileSystemProvider {
+
+        protected DenyAllAccessModesFileSystemProvider(FileSystemProvider delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public void checkAccess(Path path, AccessMode... modes) throws IOException {
+            throw new AccessDeniedException("Not allowed " + modes + " on " + path.toString());
+        }
+    }
+}


### PR DESCRIPTION
Essentially, when opening a ZFS, 2 FS are at work.
One, is the FS of the path pointing to the zip. For local jar files, it is the file:// system provider.
The other one is the ZFS.
During initialisation of the ZFS, a call to Files.isWritable is done using the zip path. This invokes the checkAccess of the system provider.
Most often in quarkus, jars (zips) are only opened to read. For the default newFileSystem(path) call, we can therefore assume that writeability does not matter.

Idea behind this work is to wrap the zip path, its filesystem, and filesystemprovider into wrapper classes. Most of the wrapped methods simply delegate back to the original path, fs, and fsp.
`path.getFileSystem()` delegates to the wrapped fs.
`fs.provider()` delegates to the wrapped fsp.
This wrapped fsp is configurable, to by default allow specific access modes, without doing io to really check them.

This is the sucessor to #6.

Related to https://github.com/quarkusio/quarkus/issues/21552.
