### PR TITLE
Implement FileSystem Caching

### DIFF
--- a/src/main/java/io/quarkus/fs/util/cache/CacheableFileSystem.java
+++ b/src/main/java/io/quarkus/fs/util/cache/CacheableFileSystem.java
@@ -1,0 +1,27 @@
+package io.quarkus.fs.util.cache;
+
+import io.quarkus.fs.util.base.DelegatingFileSystem;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+
+/**
+ * Cacheable FileSystem implementation. This delegates most of its operations to another filesystem. Calling close() call has no
+ * effect.
+ * The delegate filesystem has to be threadsafe, i.e. multiple thread might potentially read and write to it at the same time.
+ */
+public class CacheableFileSystem extends DelegatingFileSystem {
+
+    public CacheableFileSystem(FileSystem delegate) {
+        super(delegate);
+    }
+
+    public FileSystem getDelegate() {
+        return super.delegate;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // do nothing, the cache will close this fs eventually
+    }
+
+}

--- a/src/main/java/io/quarkus/fs/util/cache/FileSystemCache.java
+++ b/src/main/java/io/quarkus/fs/util/cache/FileSystemCache.java
@@ -1,0 +1,68 @@
+package io.quarkus.fs.util.cache;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class FileSystemCache implements Closeable {
+    public static final FileSystemCache INSTANCE = new FileSystemCache();
+
+    private final Map<String, CacheableFileSystem> fileSystems = new HashMap<>();
+    private final Map<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    private FileSystemCache() {
+    }
+
+    /**
+     * Constructs a new FileSystem to access the contents of a file as a file system.
+     * This caches the created FileSystem instances, until {@link #close()} is called. Calling close on the FS itself will have
+     * no effect
+     *
+     * @param fileSystemProvider
+     * @param path
+     * @param env
+     * @return
+     * @throws IOException
+     */
+    public FileSystem getOrCreateFileSystem(FileSystemProvider fileSystemProvider, Path path, Map<String, Object> env)
+            throws IOException {
+
+        String key = path.toString();
+
+        CacheableFileSystem fileSystem = fileSystems.get(key);
+        if (fileSystem == null) {
+            ReentrantLock reentrantLock = locks.computeIfAbsent(key, (p) -> new ReentrantLock());
+            try {
+                reentrantLock.lock();
+                fileSystem = fileSystems.get(key);
+                if (fileSystem == null) {
+                    fileSystem = new CacheableFileSystem(fileSystemProvider.newFileSystem(path, env));
+                    fileSystems.put(key, fileSystem);
+                }
+            } finally {
+                reentrantLock.unlock();
+            }
+        }
+
+        return fileSystem;
+    }
+
+    /**
+     * Close all cached FileSystem instances, and clear the cache.
+     */
+    @Override
+    public void close() throws IOException {
+        synchronized (fileSystems) {
+            for (CacheableFileSystem value : fileSystems.values()) {
+                value.getDelegate().close();
+            }
+            fileSystems.clear();
+        }
+    }
+}


### PR DESCRIPTION
Enables caching of filesystems created by path.

The created ZipFileSystem instance is wrapped in an delegate ensuring that any close() call has no effect.
Instead we rely on the  FileSystemCache itself to close all created FileSystems when appropriate.

This saves about 20ms of dev mode startup time.
This changes main value however is in preventing further regressions, e.g. when lots of new FileSystems would get accidentily created.

related to https://github.com/quarkusio/quarkus/issues/21552

