### PR TITLE
Save the result of Path.toUri()

### DIFF
--- a/src/main/java/io/quarkus/fs/util/base/DelegatingPath.java
+++ b/src/main/java/io/quarkus/fs/util/base/DelegatingPath.java
@@ -21,8 +21,9 @@ import java.util.function.Consumer;
 public abstract class DelegatingPath implements Path {
     protected final Path delegate;
 
+    private volatile URI uri;
+
     /**
-     *
      * @param delegate the Path to delegate to. May not be null.
      */
     protected DelegatingPath(Path delegate) {
@@ -155,7 +156,10 @@ public abstract class DelegatingPath implements Path {
 
     @Override
     public URI toUri() {
-        return delegate.toUri();
+        if (uri == null) {
+            uri = delegate.toUri();
+        }
+        return uri;
     }
 
     @Override


### PR DESCRIPTION
Converting a path multiple times to its URI representation is costly. This call can easily be cached for the sysfs path to the zip, since paths themselves are immutable.

Everytime the URI for a specific file inside a zip is created, .toURI of the original sysfs path is first called. These calls can be easily intercepted thanks to the delegates we have in place.

Saves about 250ms of dev mode startup time on https://github.com/quarkusio/quarkus/pull/22336 (6d572df).
Saves about 5ms of dev mode startup time on main

Related to https://github.com/quarkusio/quarkus/issues/21552