### PR TITLE
Prevent UnsupportedOperationException on some openjdks

### DIFF
--- a/src/main/java/io/quarkus/fs/util/FileSystemHelper.java
+++ b/src/main/java/io/quarkus/fs/util/FileSystemHelper.java
@@ -11,7 +11,7 @@ public class FileSystemHelper {
     /**
      * Same as calling {@link FileSystems#newFileSystem(Path, ClassLoader)}. The env parameter is ignored when running on java
      * versions less than 13.
-     * 
+     *
      * @param path
      * @param env only used on java 13
      * @param classLoader
@@ -24,7 +24,7 @@ public class FileSystemHelper {
 
     /**
      * Same as calling {@link FileSystems#newFileSystem(URI, Map, ClassLoader)}
-     * 
+     *
      * @param uri
      * @param env
      * @param classLoader
@@ -33,5 +33,17 @@ public class FileSystemHelper {
      */
     public static FileSystem openFS(URI uri, Map<String, ?> env, ClassLoader classLoader) throws IOException {
         return FileSystems.newFileSystem(uri, env, classLoader);
+    }
+
+    /**
+     * Wraps the given path with a {@link io.quarkus.fs.util.sysfs.PathWrapper}, preventing file system writeability checks.
+     * Only has an effect on jdk13 and up
+     *
+     * @param path
+     * @return
+     */
+    public static Path ignoreFileWriteability(Path path) {
+        // Do nothing. Some vendors' openjdk11 check that the paths filesystem equals the system on inside ZipFileSystemProvider.newFileSystem(Path, env), causing an UnsupportedOperationException.
+        return path;
     }
 }

--- a/src/main/java/io/quarkus/fs/util/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/ZipUtils.java
@@ -1,14 +1,10 @@
 
 package io.quarkus.fs.util;
 
-import io.quarkus.fs.util.sysfs.ConfigurableFileSystemProviderWrapper;
-import io.quarkus.fs.util.sysfs.FileSystemWrapper;
-import io.quarkus.fs.util.sysfs.PathWrapper;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.AccessMode;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
@@ -24,7 +20,6 @@ import java.nio.file.spi.FileSystemProvider;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.zip.ZipError;
 
 /**
@@ -207,10 +202,7 @@ public class ZipUtils {
      */
     public static FileSystem newFileSystem(Path path) throws IOException {
         try {
-            FileSystemProvider provider = new ConfigurableFileSystemProviderWrapper(path.getFileSystem().provider(),
-                    Set.of(AccessMode.WRITE));
-            FileSystem fileSystem = new FileSystemWrapper(path.getFileSystem(), provider);
-            path = new PathWrapper(path, fileSystem);
+            path = FileSystemHelper.ignoreFileWriteability(path);
             return FileSystemProviders.ZIP_PROVIDER.newFileSystem(path, DEFAULT_OWNER_ENV);
         } catch (FileSystemAlreadyExistsException e) {
             throw new IOException("fs already exists " + path, e);

--- a/src/main/java13/io/quarkus/fs/util/FileSystemHelper.java
+++ b/src/main/java13/io/quarkus/fs/util/FileSystemHelper.java
@@ -1,15 +1,21 @@
 package io.quarkus.fs.util;
 
+import io.quarkus.fs.util.sysfs.ConfigurableFileSystemProviderWrapper;
+import io.quarkus.fs.util.sysfs.FileSystemWrapper;
+import io.quarkus.fs.util.sysfs.PathWrapper;
+
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.AccessMode;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
+import java.util.Set;
 
 public class FileSystemHelper {
     /**
-     *
      * @param path
      * @param env
      * @param classLoader
@@ -22,5 +28,18 @@ public class FileSystemHelper {
 
     public static FileSystem openFS(URI uri, Map<String, ?> env, ClassLoader classLoader) throws IOException {
         return FileSystems.newFileSystem(uri, env, classLoader);
+    }
+
+    /**
+     * Wraps the given path with a {@link io.quarkus.fs.util.sysfs.PathWrapper}, preventing file system writeability checks.
+     *
+     * @param path
+     * @return
+     */
+    public static Path ignoreFileWriteability(Path path) {
+        FileSystemProvider provider = new ConfigurableFileSystemProviderWrapper(path.getFileSystem().provider(),
+                Set.of(AccessMode.WRITE));
+        FileSystem fileSystem = new FileSystemWrapper(path.getFileSystem(), provider);
+        return new PathWrapper(path, fileSystem);
     }
 }

--- a/src/test/java/io/quarkus/fs/util/ZipUtilsTest.java
+++ b/src/test/java/io/quarkus/fs/util/ZipUtilsTest.java
@@ -102,7 +102,7 @@ class ZipUtilsTest {
     }
 
     private static void assertFileExistsWithContent(final Path path, final String content) throws IOException {
-        final String readContent = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+        final String readContent = Files.readString(path);
         assertEquals(content, readContent, "Unexpected content in " + path);
     }
 }


### PR DESCRIPTION
@aloubyansky noticed that following exception happens when he is building locally with openjdk 11:
```
Caused by: java.lang.UnsupportedOperationException
    at jdk.nio.zipfs.ZipFileSystemProvider.newFileSystem (ZipFileSystemProvider.java:128)
    at io.quarkus.fs.util.ZipUtils.newFileSystem (ZipUtils.java:214)
    at io.quarkus.maven.ExtensionDescriptorMojo$1.visitEnter (ExtensionDescriptorMojo.java:545)
```
(https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/main.20is.20broken/near/265959481)

This exception does not happen on temurin jdk-11, because the whole `path.getFileSystem() != FileSystems.getDefault()` check is not present in `ZipFileSystemProvider`.

CI runs temurin.
With e.g. Oracle openjdk 11.0.2, I was able to reproduce this exception.

Starting with jdk12, the check is also removed from the main openjdk source.

temurin:
![image](https://user-images.githubusercontent.com/1223135/147325321-06bfaafc-0f97-4875-8026-017985420e2b.png)

oracle openjdk:
![image](https://user-images.githubusercontent.com/1223135/147325352-2e20c2ab-b309-4cb0-904e-fdc623504500.png)
