### PR TITLE
Handle paths with a '?' in them

### DIFF
--- a/src/main/java/io/quarkus/fs/util/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/ZipUtils.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
@@ -65,7 +66,7 @@ public class ZipUtils {
     public static URI toZipUri(Path zipFile) throws IOException {
         URI zipUri = zipFile.toUri();
         try {
-            zipUri = new URI(JAR_URI_PREFIX + zipUri.getScheme(), zipUri.getPath(), null);
+            zipUri = new URL(JAR_URI_PREFIX + zipUri.getScheme() + "://" + zipUri.getRawPath() + "!/").toURI();
         } catch (URISyntaxException e) {
             throw new IOException("Failed to create a JAR URI for " + zipFile, e);
         }


### PR DESCRIPTION
This is actually quite tricky, as URI does not let you create these by
default, you need to sneak them in using URL.toUrl(). If you attempt to
use the URI constructor directly then a '?' is interpreted as the start
of the query string, and %3f is encoded to %253f, so there is no way to
actually pass in an ecoded question mark to the URI constructor.