### PR TITLE
Drop wrapping of OutputStream in ZipUtils

### DIFF
--- a/src/main/java/io/quarkus/fs/util/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/ZipUtils.java
@@ -251,42 +251,16 @@ public class ZipUtils {
     /**
      * This is a hack to get past the <a href="https://bugs.openjdk.java.net/browse/JDK-8232879">JDK-8232879</a>
      * issue which causes CRC errors when writing out data to (jar) files using ZipFileSystem.
-     * TODO: Get rid of this method as soon as JDK-8232879 gets fixed and released in a public version
+     * <p>
+     * Made into a no-op given the JDK issue has been fixed.
      *
      * @param original The original outputstream which will be wrapped into a new outputstream
      *        that delegates to this one.
      * @return
+     * @deprecated Do not wrap the OutputStream, it is not needed anymore.
      */
+    @Deprecated(forRemoval = true, since = "0.11.0")
     public static OutputStream wrapForJDK8232879(final OutputStream original) {
-        return new OutputStream() {
-            @Override
-            public void write(final byte[] b) throws IOException {
-                original.write(b, 0, b.length);
-            }
-
-            @Override
-            public void write(final byte[] b, final int off, final int len) throws IOException {
-                original.write(b, off, len);
-            }
-
-            @Override
-            public void flush() throws IOException {
-                original.flush();
-            }
-
-            @Override
-            public void close() throws IOException {
-                original.close();
-            }
-
-            @Override
-            public void write(final int b) throws IOException {
-                // we call the 3 arg write(...) method here, instead
-                // of the single arg one to bypass the JDK-8232879 issue
-                final byte[] buf = new byte[1];
-                buf[0] = (byte) (b & 0xff);
-                this.write(buf, 0, 1);
-            }
-        };
+        return original;
     }
 }


### PR DESCRIPTION
The JDK issue has been fixed.

Fixes #18