### PR TITLE
Read-only ZIP FileSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,72 @@
 
 Utilities for low-level filesystem operations.
 
+## Read-Only ZIP FileSystem
+
+The `io.quarkus.fs.util.rozip` package contains a read-only `java.nio.file.FileSystem` implementation for ZIP/JAR archives. It was built to replace the JDK's `ZipFileSystem` in Quarkus, where thread interrupts during augmentation could close shared file channels and corrupt the build.
+
+### Why it exists
+
+The JDK's `ZipFileSystem` reads through a `FileChannel`, which is an `InterruptibleChannel`. If any thread that shares the channel is interrupted, the channel is closed for all threads ([JDK-8316882](https://bugs.openjdk.org/browse/JDK-8316882)). This implementation uses `RandomAccessFile` instead, whose I/O operations are not affected by thread interrupts.
+
+### Usage
+
+```java
+// Via the public API (returns FileSystem)
+FileSystem fs = ZipUtils.openReadOnly(path);
+
+// Or directly (returns the concrete type for direct API access)
+ReadOnlyZipFileSystem fs = ReadOnlyZipFileSystem.open(path);
+```
+
+Each call opens a new, independent file handle. No caching or deduplication is performed — callers that open the same archive multiple times should cache the returned instance themselves.
+
+### How it works
+
+Entry data is read on demand from the underlying `RandomAccessFile`. All reads are synchronized on the file handle for thread safety. Compressed data is decompressed into a `byte[]` using a pooled `Inflater` (up to 8 instances per filesystem). The full decompressed content is returned to the caller — there is no streaming API.
+
+### Comparison with JDK ZipFileSystem
+
+| | Rozip | JDK ZipFileSystem |
+|---|---|---|
+| **Thread interrupt safety** | Immune — uses `RandomAccessFile` | Vulnerable — `FileChannel` is an `InterruptibleChannel` ([JDK-8316882](https://bugs.openjdk.org/browse/JDK-8316882)) |
+| **Read/write** | Read-only | Read-write |
+| **NIO compatibility** | Read-only `java.nio.file` API | Full |
+| **Direct API** | `entryExists(String)` bypasses NIO dispatch | N/A |
+| **ServiceLoader discovery** | No — access via `ZipUtils.openReadOnly()` or `ReadOnlyZipFileSystem.open()` | Yes |
+| **Central directory memory** | Compact sorted arrays (~60% less) | `HashMap`-based |
+| **Central directory size limit** | 256 MB | No limit |
+| **Entry data reads** | Fully materialized `byte[]` per read | Memory-mapped or channel-based streaming |
+| **Entry caching** | Opt-in `SoftReference` cache (`-Drozip.cache=true`) | Internal caching |
+| **Inflater pooling** | Per-filesystem pool (up to 8) | Per-filesystem pool |
+| **Compression methods** | STORED, DEFLATED | STORED, DEFLATED |
+| **ZIP64** | Yes (entries capped at 256 MB) | Yes (no entry size cap) |
+| **Data descriptors** | Yes (32-bit and ZIP64) | Yes |
+| **Extended timestamps** | Unix (0x5455) and NTFS (0x000a) | Unix (0x5455) and NTFS (0x000a) |
+| **Entry name encoding** | UTF-8 only | Configurable (default UTF-8, respects EFS flag) |
+| **CRC-32 verification** | Yes | Yes |
+| **Zip bomb protection** | 256 MB entry cap, 1000:1 ratio limit | No |
+| **Encryption** | No | No |
+| **Multi-disk archives** | No | No |
+
+### Limitations and Quarkus impact
+
+- **Read-only.** Write operations (`Files.copy()`, `Files.move()`, `Files.delete()`, `Files.newOutputStream()`, `Files.createDirectory()`) throw `ReadOnlyFileSystemException`. Quarkus only reads JARs during augmentation and at runtime, so this is not a limitation in practice.
+
+- **UTF-8 entry names only.** The Language Encoding Flag (general-purpose bit 11) is ignored; all names are decoded as UTF-8. Archives created by older tools with CP437-encoded non-ASCII filenames will produce incorrect entry names. Modern JARs universally use UTF-8, so this does not affect Quarkus dependencies.
+
+- **256 MB entry and central directory cap.** Individual entries and the central directory are each limited to 256 MB. This is a zip-bomb defense. Quarkus JARs are well below this threshold; an uber-JAR would need hundreds of thousands of entries to approach the central directory limit.
+
+- **No encryption support.** Encrypted ZIP entries cannot be read. Quarkus itself does not use encrypted JARs, but if a user dependency ships as an encrypted JAR, it will fail to open at build time. Note that the JDK `ZipFileSystem` also does not support encryption, so this is not a regression.
+
+- **No multi-disk archive support.** Split/spanned archives are not supported. Quarkus dependencies are always single-file JARs.
+
+- **No nested archive support.** Reading a ZIP-in-ZIP (e.g. a JAR inside an uber-JAR) requires extracting the inner bytes with `Files.readAllBytes()` and opening separately. This matches the JDK behavior. Quarkus handles nested JARs at a higher level and does not rely on filesystem-level nesting.
+
+- **65535-entry edge case.** A non-ZIP64 archive with exactly 65535 entries is misidentified as ZIP64, causing an `IOException` if no ZIP64 end-of-central-directory record is present. In practice, most tools emit ZIP64 structures at that entry count, and Quarkus JARs are well below this threshold.
+
+- **No ServiceLoader discovery.** The filesystem provider is not registered via `META-INF/services` and cannot be used with `FileSystems.newFileSystem(URI, ...)`. Access is through `ZipUtils.openReadOnly()` or `ReadOnlyZipFileSystem.open()`. This is intentional — Quarkus controls all call sites and does not need URI-based discovery.
+
 ## Release
 
 To release a new version, follow these steps:

--- a/src/main/java/io/quarkus/fs/util/ZipUtils.java
+++ b/src/main/java/io/quarkus/fs/util/ZipUtils.java
@@ -1,6 +1,7 @@
 
 package io.quarkus.fs.util;
 
+import io.quarkus.fs.util.rozip.ReadOnlyZipFileSystem;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -259,6 +260,27 @@ public class ZipUtils {
     @Deprecated
     public static FileSystem newFileSystem(final Path path, ClassLoader classLoader) throws IOException {
         return newFileSystem(path, Collections.emptyMap());
+    }
+
+    /**
+     * Opens a read-only, non-interruptible {@link FileSystem} for the given ZIP/JAR file.
+     * <p>
+     * Unlike {@link #newFileSystem(Path)}, this implementation uses
+     * {@link java.io.RandomAccessFile} instead of {@link java.nio.channels.FileChannel},
+     * making it immune to thread-interrupt-induced channel closures
+     * (<a href="https://bugs.openjdk.org/browse/JDK-8316882">JDK-8316882</a>).
+     * <p>
+     * Entry data is fully materialized in memory on each read (both the
+     * compressed and uncompressed bytes). Individual entries are capped at
+     * 256 MB uncompressed. Callers reading many entries concurrently against
+     * the same filesystem should be aware of the resulting heap usage.
+     *
+     * @param path the ZIP or JAR file
+     * @return a read-only {@link FileSystem} instance
+     * @throws IOException if the file cannot be read or is not a valid ZIP archive
+     */
+    public static FileSystem openReadOnly(Path path) throws IOException {
+        return ReadOnlyZipFileSystem.open(path);
     }
 
     /**

--- a/src/main/java/io/quarkus/fs/util/rozip/CompactEntryTable.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/CompactEntryTable.java
@@ -1,0 +1,623 @@
+package io.quarkus.fs.util.rozip;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A memory-efficient, immutable index of ZIP central directory entries.
+ * <p>
+ * This replaces the conventional {@code Map<String, ZipEntryInfo>} and
+ * {@code Map<String, List<String>>} (directory children) with a flat,
+ * sorted structure that eliminates per-entry object overhead from
+ * {@link java.util.HashMap.Node}, {@link String}, and {@link ZipEntryInfo}
+ * instances. Measured savings are approximately 60% compared to the
+ * map-based representation (e.g. 9.9 MB vs 25.5 MB for 96K entries).
+ *
+ * <h2>Data layout</h2>
+ *
+ * All entry names are encoded as UTF-8 and concatenated into a single
+ * {@code byte[]} ({@link #nameBytes}). A parallel {@code int[]}
+ * ({@link #nameOffsets}) stores the start offset of each name;
+ * {@code nameOffsets[i+1] - nameOffsets[i]} gives the length of name
+ * {@code i}. The entries are sorted by unsigned byte order of their
+ * UTF-8 names, which enables O(log n) lookup via binary search.
+ * <p>
+ * Entry metadata (compressed size, uncompressed size, CRC-32, local
+ * header offset, last-modified time, compression method, directory flag)
+ * is stored in parallel primitive arrays indexed by the same entry index,
+ * keeping data dense and cache-friendly.
+ *
+ * <pre>
+ * nameBytes:   [ c o m / A . c l a s s c o m / B . c l a s s ]
+ * nameOffsets: [ 0,                    11,                    22 ]
+ *               ^--- entry 0 ---^      ^--- entry 1 ---^
+ *
+ * compressedSizes:   [ 1234,  5678  ]   (parallel, same index)
+ * uncompressedSizes: [ 2048,  8192  ]
+ * crc32Values:       [ 0xAB, 0xCD   ]
+ * ...
+ * </pre>
+ *
+ * <h2>Directory tree</h2>
+ *
+ * Directory children are derived from the sorted entry names at query
+ * time rather than stored in a separate map. Because entries sharing
+ * a directory prefix are adjacent in sorted
+ * order, listing the children of directory {@code "com/example"} is a
+ * binary search for the prefix {@code "com/example/"} followed by a
+ * forward scan that extracts unique immediate child names. Implicit
+ * directories (not present as explicit entries in the ZIP but implied
+ * by file paths) are detected by checking whether any entry name
+ * starts with the directory prefix.
+ *
+ * <h2>Thread safety</h2>
+ *
+ * Instances are immutable after construction and safe for concurrent
+ * use by multiple threads without synchronization.
+ *
+ * @see ZipCentralDirectory
+ * @see ReadOnlyZipFileSystem
+ */
+final class CompactEntryTable {
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    // Central directory entry header field offsets and sizes
+    private static final int CD_HEADER_SIZE = 46;
+    private static final int CD_OFF_COMPRESSION_METHOD = 10;
+    private static final int CD_OFF_DOS_TIME = 12;
+    private static final int CD_OFF_DOS_DATE = 14;
+    private static final int CD_OFF_CRC32 = 16;
+    private static final int CD_OFF_COMPRESSED_SIZE = 20;
+    private static final int CD_OFF_UNCOMPRESSED_SIZE = 24;
+    private static final int CD_OFF_NAME_LENGTH = 28;
+    private static final int CD_OFF_EXTRA_LENGTH = 30;
+    private static final int CD_OFF_COMMENT_LENGTH = 32;
+    private static final int CD_OFF_LOCAL_HEADER_OFFSET = 42;
+
+    private final byte[] nameBytes;
+    private final int[] nameOffsets;
+    private final long[] localHeaderOffsets;
+    private final long[] compressedSizes;
+    private final long[] uncompressedSizes;
+    private final int[] crc32Values;
+    private final long[] lastModifiedTimes;
+    private final byte[] compressionMethods;
+    private final BitSet directories;
+    private final int entryCount;
+
+    /**
+     * Builds a compact entry table directly from raw central directory bytes.
+     * Parses entry metadata and references names as (offset, length) pairs
+     * into {@code cdBytes} throughout parsing and sorting, then copies the
+     * sorted names into a single concatenated byte array.
+     *
+     * @param cdBytes the raw central directory bytes
+     * @param cdSize the number of valid bytes in {@code cdBytes}
+     * @param totalEntries the declared number of entries
+     * @param cdOffset the absolute file offset of the central directory (for error messages)
+     * @return a new compact entry table
+     * @throws IOException if the central directory is malformed
+     */
+    static CompactEntryTable buildFromCentralDirectory(byte[] cdBytes, int cdSize,
+            long totalEntries, long cdOffset) throws IOException {
+        int count = (int) Math.min(totalEntries, Integer.MAX_VALUE);
+        if (count == 0) {
+            return empty();
+        }
+
+        int[] nameStarts = new int[count];
+        int[] nameLens = new int[count];
+        long[] tmpLocalHeaderOffsets = new long[count];
+        long[] tmpCompressedSizes = new long[count];
+        long[] tmpUncompressedSizes = new long[count];
+        int[] tmpCrc32Values = new int[count];
+        long[] tmpLastModifiedTimes = new long[count];
+        byte[] tmpCompressionMethods = new byte[count];
+        BitSet tmpDirectories = new BitSet(count);
+
+        int actualCount = 0;
+        int pos = 0;
+        for (int i = 0; i < count && pos + CD_HEADER_SIZE <= cdSize; i++) {
+            if (LittleEndian.readInt32(cdBytes, pos) != ZipCentralDirectory.CENTRAL_DIR_SIG) {
+                throw new IOException(
+                        "Invalid central directory entry signature at offset " + (cdOffset + pos));
+            }
+
+            int method = LittleEndian.readUint16(cdBytes, pos + CD_OFF_COMPRESSION_METHOD);
+            int dosTime = LittleEndian.readUint16(cdBytes, pos + CD_OFF_DOS_TIME);
+            int dosDate = LittleEndian.readUint16(cdBytes, pos + CD_OFF_DOS_DATE);
+            long crc32 = LittleEndian.readUint32(cdBytes, pos + CD_OFF_CRC32);
+            long compressedSize = LittleEndian.readUint32(cdBytes, pos + CD_OFF_COMPRESSED_SIZE);
+            long uncompressedSize = LittleEndian.readUint32(cdBytes, pos + CD_OFF_UNCOMPRESSED_SIZE);
+            int origNameLen = LittleEndian.readUint16(cdBytes, pos + CD_OFF_NAME_LENGTH);
+            int extraLen = LittleEndian.readUint16(cdBytes, pos + CD_OFF_EXTRA_LENGTH);
+            int commentLen = LittleEndian.readUint16(cdBytes, pos + CD_OFF_COMMENT_LENGTH);
+            long localHeaderOffset = LittleEndian.readUint32(cdBytes, pos + CD_OFF_LOCAL_HEADER_OFFSET);
+
+            if (pos + CD_HEADER_SIZE + origNameLen + extraLen + commentLen > cdSize) {
+                throw new IOException("Truncated central directory entry at offset " + (cdOffset + pos));
+            }
+
+            int extraOffset = pos + CD_HEADER_SIZE + origNameLen;
+
+            int nameStart = pos + CD_HEADER_SIZE;
+            int nameLen = origNameLen;
+            if (nameLen > 0 && cdBytes[nameStart] == '/') {
+                nameStart++;
+                nameLen--;
+            }
+            boolean isDirectory = nameLen > 0 && cdBytes[nameStart + nameLen - 1] == '/';
+            if (isDirectory) {
+                nameLen--;
+            }
+
+            nameStarts[actualCount] = nameStart;
+            nameLens[actualCount] = nameLen;
+
+            if (ZipCentralDirectory.hasZip64Overrides(compressedSize, uncompressedSize,
+                    localHeaderOffset)) {
+                long[] zip64 = ZipCentralDirectory.readZip64Extra(cdBytes, extraOffset, extraLen,
+                        uncompressedSize, compressedSize, localHeaderOffset);
+                uncompressedSize = zip64[0];
+                compressedSize = zip64[1];
+                localHeaderOffset = zip64[2];
+            }
+
+            long lastModified = ZipCentralDirectory.readTimestampFromExtra(cdBytes,
+                    extraOffset, extraLen,
+                    ZipCentralDirectory.dosToEpochMillis(dosDate, dosTime));
+
+            tmpLocalHeaderOffsets[actualCount] = localHeaderOffset;
+            tmpCompressedSizes[actualCount] = compressedSize;
+            tmpUncompressedSizes[actualCount] = uncompressedSize;
+            tmpCrc32Values[actualCount] = (int) crc32;
+            tmpLastModifiedTimes[actualCount] = lastModified;
+            tmpCompressionMethods[actualCount] = (byte) method;
+            if (isDirectory) {
+                tmpDirectories.set(actualCount);
+            }
+
+            actualCount++;
+            pos += CD_HEADER_SIZE + origNameLen + extraLen + commentLen;
+        }
+
+        return sortAndBuildFromCd(actualCount, cdBytes, nameStarts, nameLens,
+                tmpLocalHeaderOffsets, tmpCompressedSizes, tmpUncompressedSizes,
+                tmpCrc32Values, tmpLastModifiedTimes, tmpCompressionMethods, tmpDirectories);
+    }
+
+    private static CompactEntryTable empty() {
+        return new CompactEntryTable(EMPTY_BYTES, new int[] { 0 },
+                new long[0], new long[0], new long[0], new int[0],
+                new long[0], new byte[0], new BitSet(), 0);
+    }
+
+    /**
+     * Sorts entries by name, deduplicates, and builds the final compact
+     * arrays. Names are referenced as (offset, length) pairs into
+     * {@code cdBytes} and copied into the concatenated name array only
+     * once, in sorted order.
+     */
+    private static CompactEntryTable sortAndBuildFromCd(int count, byte[] cdBytes,
+            int[] nameStarts, int[] nameLens,
+            long[] tmpLocalHeaderOffsets, long[] tmpCompressedSizes,
+            long[] tmpUncompressedSizes, int[] tmpCrc32Values,
+            long[] tmpLastModifiedTimes, byte[] tmpCompressionMethods,
+            BitSet tmpDirectories) {
+
+        int[] sortOrder = new int[count];
+        for (int i = 0; i < count; i++) {
+            sortOrder[i] = i;
+        }
+        mergeSort(sortOrder, count, (a, b) -> compareBytesRange(
+                cdBytes, nameStarts[a], nameLens[a],
+                cdBytes, nameStarts[b], nameLens[b]));
+
+        boolean[] skip = new boolean[count];
+        int skipCount = 0;
+        int totalNameBytes = 0;
+        for (int i = 0; i < count; i++) {
+            if (i < count - 1
+                    && nameLens[sortOrder[i]] == nameLens[sortOrder[i + 1]]
+                    && regionEquals(cdBytes, nameStarts[sortOrder[i]],
+                            cdBytes, nameStarts[sortOrder[i + 1]],
+                            nameLens[sortOrder[i]])) {
+                int skipIdx = sortOrder[i] < sortOrder[i + 1] ? i : i + 1;
+                if (!skip[skipIdx]) {
+                    skip[skipIdx] = true;
+                    skipCount++;
+                }
+            }
+            if (!skip[i]) {
+                totalNameBytes += nameLens[sortOrder[i]];
+            }
+        }
+
+        int finalCount = count - skipCount;
+
+        byte[] nameBytesArr = new byte[totalNameBytes];
+        int[] nameOffsetsArr = new int[finalCount + 1];
+        long[] localHeaderOffsetsArr = new long[finalCount];
+        long[] compressedSizesArr = new long[finalCount];
+        long[] uncompressedSizesArr = new long[finalCount];
+        int[] crc32Arr = new int[finalCount];
+        long[] lastModArr = new long[finalCount];
+        byte[] methodsArr = new byte[finalCount];
+        BitSet dirsSet = new BitSet(finalCount);
+
+        int namePos = 0;
+        int outIdx = 0;
+        for (int i = 0; i < count; i++) {
+            if (skip[i]) {
+                continue;
+            }
+            int orig = sortOrder[i];
+            int nStart = nameStarts[orig];
+            int nLen = nameLens[orig];
+
+            nameOffsetsArr[outIdx] = namePos;
+            System.arraycopy(cdBytes, nStart, nameBytesArr, namePos, nLen);
+            namePos += nLen;
+
+            localHeaderOffsetsArr[outIdx] = tmpLocalHeaderOffsets[orig];
+            compressedSizesArr[outIdx] = tmpCompressedSizes[orig];
+            uncompressedSizesArr[outIdx] = tmpUncompressedSizes[orig];
+            crc32Arr[outIdx] = tmpCrc32Values[orig];
+            lastModArr[outIdx] = tmpLastModifiedTimes[orig];
+            methodsArr[outIdx] = tmpCompressionMethods[orig];
+            if (tmpDirectories.get(orig)) {
+                dirsSet.set(outIdx);
+            }
+            outIdx++;
+        }
+        nameOffsetsArr[finalCount] = namePos;
+
+        return new CompactEntryTable(nameBytesArr, nameOffsetsArr,
+                localHeaderOffsetsArr, compressedSizesArr, uncompressedSizesArr,
+                crc32Arr, lastModArr, methodsArr, dirsSet, finalCount);
+    }
+
+    /**
+     * Constructs a table from pre-built parallel arrays. All arrays must
+     * be consistently indexed: element {@code i} across all arrays
+     * describes the same entry. Names must be sorted by unsigned UTF-8
+     * byte order.
+     */
+    private CompactEntryTable(byte[] nameBytes, int[] nameOffsets,
+            long[] localHeaderOffsets, long[] compressedSizes,
+            long[] uncompressedSizes, int[] crc32Values,
+            long[] lastModifiedTimes, byte[] compressionMethods,
+            BitSet directories, int entryCount) {
+        this.nameBytes = nameBytes;
+        this.nameOffsets = nameOffsets;
+        this.localHeaderOffsets = localHeaderOffsets;
+        this.compressedSizes = compressedSizes;
+        this.uncompressedSizes = uncompressedSizes;
+        this.crc32Values = crc32Values;
+        this.lastModifiedTimes = lastModifiedTimes;
+        this.compressionMethods = compressionMethods;
+        this.directories = directories;
+        this.entryCount = entryCount;
+    }
+
+    /**
+     * @return the number of entries in this table
+     */
+    int size() {
+        return entryCount;
+    }
+
+    /**
+     * Looks up an entry by name. A new {@link ZipEntryInfo} is constructed
+     * on each call from the parallel arrays; the caller's {@code name}
+     * string is reused as the record's name field.
+     *
+     * @param name the entry name (without leading {@code "/"})
+     * @return the entry info, or {@code null} if not found
+     */
+    ZipEntryInfo getEntry(String name) {
+        int index = binarySearch(toUTF8(name));
+        if (index < 0) {
+            return null;
+        }
+        return entryAt(index, name);
+    }
+
+    /**
+     * Checks whether the given name exists as an explicit entry or as an
+     * implicit directory (i.e. at least one entry has {@code name + "/"} as
+     * a prefix).
+     *
+     * @param name the entry or directory name
+     * @return {@code true} if the name exists
+     */
+    boolean exists(String name) {
+        byte[] nameUtf8 = toUTF8(name);
+        if (binarySearch(nameUtf8) >= 0) {
+            return true;
+        }
+        return hasEntriesUnder(nameUtf8);
+    }
+
+    /**
+     * Checks whether any entry exists whose name starts with
+     * {@code name + "/"}. This detects both explicit and implicit
+     * directories.
+     *
+     * @param name the directory name to check
+     * @return {@code true} if at least one entry is under this directory
+     */
+    boolean hasEntriesUnder(String name) {
+        return hasEntriesUnder(toUTF8(name));
+    }
+
+    /**
+     * Returns the immediate children of the given directory. Child names
+     * are simple names (e.g. {@code "Foo.class"}, {@code "sub"}), not
+     * full paths. Both files and subdirectories are included.
+     * <p>
+     * For the root directory, pass the empty string {@code ""}.
+     *
+     * @param name the directory name (empty string for root)
+     * @return an unmodifiable list of child names, an empty list for an
+     *         empty explicit directory, or {@code null} if the name is
+     *         not a directory
+     */
+    List<String> getDirectoryChildren(String name) {
+        byte[] nameUtf8 = toUTF8(name);
+        byte[] prefix = toPrefixBytes(nameUtf8);
+
+        int start = lowerBound(prefix);
+        if (start >= entryCount || !nameStartsWith(start, prefix)) {
+            if (nameUtf8.length == 0) {
+                return List.of();
+            }
+            int idx = binarySearch(nameUtf8);
+            if (idx >= 0 && directories.get(idx)) {
+                return List.of();
+            }
+            return null;
+        }
+
+        List<String> children = new ArrayList<>();
+        int prevStart = -1;
+        int prevLen = -1;
+        for (int i = start; i < entryCount && nameStartsWith(i, prefix); i++) {
+            int childStart = nameOffsets[i] + prefix.length;
+            int childLen = immediateChildLen(childStart, nameOffsets[i + 1]);
+            if (childLen != prevLen
+                    || !regionEquals(nameBytes, childStart, nameBytes, prevStart, childLen)) {
+                children.add(new String(nameBytes, childStart, childLen, StandardCharsets.UTF_8));
+                prevStart = childStart;
+                prevLen = childLen;
+            }
+        }
+        return Collections.unmodifiableList(children);
+    }
+
+    /**
+     * Constructs a {@link ZipEntryInfo} from the parallel arrays at the
+     * given index.
+     *
+     * @param index position in the sorted arrays
+     * @param name the caller's name string, reused as the record's name
+     */
+    private ZipEntryInfo entryAt(int index, String name) {
+        return new ZipEntryInfo(
+                name,
+                compressedSizes[index],
+                uncompressedSizes[index],
+                compressionMethods[index] & 0xFF,
+                Integer.toUnsignedLong(crc32Values[index]),
+                localHeaderOffsets[index],
+                directories.get(index),
+                lastModifiedTimes[index]);
+    }
+
+    /**
+     * Binary search for an exact name match.
+     *
+     * @param query the UTF-8 encoded name to search for
+     * @return the index if found, or {@code -(insertion point) - 1} if not
+     */
+    private int binarySearch(byte[] query) {
+        int lo = 0, hi = entryCount - 1;
+        while (lo <= hi) {
+            int mid = (lo + hi) >>> 1;
+            int cmp = compareName(mid, query, 0, query.length);
+            if (cmp < 0) {
+                lo = mid + 1;
+            } else if (cmp > 0) {
+                hi = mid - 1;
+            } else {
+                return mid;
+            }
+        }
+        return -(lo + 1);
+    }
+
+    /**
+     * Compares the name at {@code index} against a query byte range
+     * using unsigned byte comparison. Returns negative if the stored
+     * name is less than the query, zero if equal, positive if greater.
+     */
+    private int compareName(int index, byte[] query, int queryOffset, int queryLen) {
+        int start = nameOffsets[index];
+        int len = nameOffsets[index + 1] - start;
+        return compareBytesRange(nameBytes, start, len, query, queryOffset, queryLen);
+    }
+
+    /**
+     * Finds the index of the first entry whose name is greater than or
+     * equal to {@code prefix} (lower bound). Returns {@link #entryCount}
+     * if all names are strictly less than the prefix.
+     */
+    private int lowerBound(byte[] prefix) {
+        if (prefix.length == 0) {
+            return 0;
+        }
+        int lo = 0, hi = entryCount;
+        while (lo < hi) {
+            int mid = (lo + hi) >>> 1;
+            if (compareNamePrefix(mid, prefix) < 0) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+
+    /**
+     * Compares the name at {@code index} against {@code prefix} for
+     * lower-bound searching. Returns negative if the name is strictly
+     * less than the prefix, zero or positive if the name starts with
+     * (or is greater than) the prefix.
+     */
+    private int compareNamePrefix(int index, byte[] prefix) {
+        int start = nameOffsets[index];
+        int len = nameOffsets[index + 1] - start;
+        int minLen = Math.min(len, prefix.length);
+        for (int i = 0; i < minLen; i++) {
+            int diff = (nameBytes[start + i] & 0xFF) - (prefix[i] & 0xFF);
+            if (diff != 0) {
+                return diff;
+            }
+        }
+        return len < prefix.length ? -1 : 0;
+    }
+
+    /**
+     * Returns {@code true} if the name at {@code index} starts with
+     * the given prefix bytes.
+     */
+    private boolean nameStartsWith(int index, byte[] prefix) {
+        if (prefix.length == 0) {
+            return true;
+        }
+        int start = nameOffsets[index];
+        int len = nameOffsets[index + 1] - start;
+        return len >= prefix.length
+                && regionEquals(nameBytes, start, prefix, 0, prefix.length);
+    }
+
+    /**
+     * Returns the length of the immediate child name starting at
+     * {@code childStart} — the number of bytes before the next
+     * {@code '/'} or {@code nameEnd}, whichever comes first.
+     */
+    private int immediateChildLen(int childStart, int nameEnd) {
+        for (int i = childStart; i < nameEnd; i++) {
+            if (nameBytes[i] == '/') {
+                return i - childStart;
+            }
+        }
+        return nameEnd - childStart;
+    }
+
+    /**
+     * Checks whether any entry name starts with {@code nameUtf8 + "/"}.
+     *
+     * @param nameUtf8 the pre-converted UTF-8 directory name bytes
+     * @return {@code true} if at least one entry exists under this directory
+     */
+    private boolean hasEntriesUnder(byte[] nameUtf8) {
+        byte[] prefix = toPrefixBytes(nameUtf8);
+        int lb = lowerBound(prefix);
+        return lb < entryCount && nameStartsWith(lb, prefix);
+    }
+
+    /**
+     * Encodes a string to UTF-8 bytes. Single conversion point for all public methods.
+     */
+    private static byte[] toUTF8(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Appends {@code '/'} to the given name bytes to form a directory
+     * prefix suitable for {@link #lowerBound} and {@link #nameStartsWith}
+     * searches. Returns {@link #EMPTY_BYTES} for the root directory
+     * (empty input).
+     */
+    private static byte[] toPrefixBytes(byte[] nameUtf8) {
+        if (nameUtf8.length == 0) {
+            return EMPTY_BYTES;
+        }
+        byte[] prefix = new byte[nameUtf8.length + 1];
+        System.arraycopy(nameUtf8, 0, prefix, 0, nameUtf8.length);
+        prefix[nameUtf8.length] = '/';
+        return prefix;
+    }
+
+    @FunctionalInterface
+    private interface IntComparator {
+        int compare(int a, int b);
+    }
+
+    /**
+     * Sorts an {@code int[]} of indices using an iterative bottom-up merge
+     * sort with a custom comparator. Operates directly on primitive
+     * {@code int} values.
+     */
+    private static void mergeSort(int[] arr, int len, IntComparator cmp) {
+        int[] tmp = new int[len];
+        int[] src = arr, dst = tmp;
+        for (int width = 1; width < len; width *= 2) {
+            for (int lo = 0; lo < len; lo += width * 2) {
+                int mid = Math.min(lo + width, len);
+                int hi = Math.min(lo + width * 2, len);
+                int i = lo, j = mid, k = lo;
+                while (i < mid && j < hi) {
+                    dst[k++] = cmp.compare(src[i], src[j]) <= 0 ? src[i++] : src[j++];
+                }
+                while (i < mid) {
+                    dst[k++] = src[i++];
+                }
+                while (j < hi) {
+                    dst[k++] = src[j++];
+                }
+            }
+            int[] swap = src;
+            src = dst;
+            dst = swap;
+        }
+        if (src != arr) {
+            System.arraycopy(src, 0, arr, 0, len);
+        }
+    }
+
+    /**
+     * Lexicographic comparison of two byte ranges using unsigned byte
+     * values. Used by {@link #sortAndBuildFromCd} to sort entry names
+     * referenced as (offset, length) pairs.
+     */
+    private static int compareBytesRange(byte[] a, int aOff, int aLen,
+            byte[] b, int bOff, int bLen) {
+        int minLen = Math.min(aLen, bLen);
+        for (int i = 0; i < minLen; i++) {
+            int diff = (a[aOff + i] & 0xFF) - (b[bOff + i] & 0xFF);
+            if (diff != 0) {
+                return diff;
+            }
+        }
+        return aLen - bLen;
+    }
+
+    /**
+     * Returns {@code true} if two byte ranges contain identical bytes.
+     */
+    private static boolean regionEquals(byte[] a, int aOff, byte[] b, int bOff, int len) {
+        for (int i = 0; i < len; i++) {
+            if (a[aOff + i] != b[bOff + i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/LittleEndian.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/LittleEndian.java
@@ -1,0 +1,71 @@
+package io.quarkus.fs.util.rozip;
+
+/**
+ * Little-endian byte-reading utilities for ZIP binary parsing.
+ */
+final class LittleEndian {
+
+    private LittleEndian() {
+    }
+
+    /**
+     * Reads an unsigned 16-bit integer from two bytes in little-endian order.
+     *
+     * @param buf byte array to read from
+     * @param off offset of the first byte
+     * @return the unsigned 16-bit value as an {@code int} in the range 0..65535
+     */
+    static int readUint16(byte[] buf, int off) {
+        return (buf[off] & 0xFF) | ((buf[off + 1] & 0xFF) << 8);
+    }
+
+    /**
+     * Reads an unsigned 32-bit integer from four bytes in little-endian order.
+     *
+     * @param buf byte array to read from
+     * @param off offset of the first byte
+     * @return the unsigned 32-bit value as a {@code long} in the range 0..4294967295
+     */
+    static long readUint32(byte[] buf, int off) {
+        return (buf[off] & 0xFFL)
+                | ((buf[off + 1] & 0xFFL) << 8)
+                | ((buf[off + 2] & 0xFFL) << 16)
+                | ((buf[off + 3] & 0xFFL) << 24);
+    }
+
+    /**
+     * Reads a signed 32-bit integer from four bytes in little-endian order.
+     *
+     * @param buf byte array to read from
+     * @param off offset of the first byte
+     * @return the signed 32-bit value as an {@code int}
+     */
+    static int readInt32(byte[] buf, int off) {
+        return (buf[off] & 0xFF)
+                | ((buf[off + 1] & 0xFF) << 8)
+                | ((buf[off + 2] & 0xFF) << 16)
+                | ((buf[off + 3] & 0xFF) << 24);
+    }
+
+    /**
+     * Reads a 64-bit integer from eight bytes in little-endian order.
+     * <p>
+     * The result is returned as a signed {@code long}. Values with bit 63 set will appear negative.
+     * In practice, ZIP64 fields never exceed approximately 2<sup>63</sup>, which is the same
+     * limitation imposed by the JDK's {@code ZipUtils}.
+     *
+     * @param buf byte array to read from
+     * @param off offset of the first byte
+     * @return the 64-bit value as a signed {@code long}
+     */
+    static long readUint64(byte[] buf, int off) {
+        return (buf[off] & 0xFFL)
+                | ((buf[off + 1] & 0xFFL) << 8)
+                | ((buf[off + 2] & 0xFFL) << 16)
+                | ((buf[off + 3] & 0xFFL) << 24)
+                | ((buf[off + 4] & 0xFFL) << 32)
+                | ((buf[off + 5] & 0xFFL) << 40)
+                | ((buf[off + 6] & 0xFFL) << 48)
+                | ((buf[off + 7] & 0xFFL) << 56);
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipAttributes.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipAttributes.java
@@ -1,0 +1,80 @@
+package io.quarkus.fs.util.rozip;
+
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+
+/**
+ * Read-only {@link BasicFileAttributes} implementation backed by {@link ZipEntryInfo}.
+ * <p>
+ * ZIP archives do not track access or creation times separately, so all three
+ * timestamps ({@link #lastModifiedTime()}, {@link #lastAccessTime()},
+ * {@link #creationTime()}) return the same value derived from the entry's
+ * DOS-format last-modified timestamp.
+ */
+final class ReadOnlyZipAttributes implements BasicFileAttributes {
+
+    /**
+     * Synthetic attributes for the root directory {@code "/"}, which has no
+     * corresponding entry in the central directory.
+     */
+    static final ReadOnlyZipAttributes ROOT = new ReadOnlyZipAttributes(null);
+
+    private final ZipEntryInfo entry;
+
+    /**
+     * @param entry the backing entry info, or {@code null} for the root directory
+     */
+    ReadOnlyZipAttributes(ZipEntryInfo entry) {
+        this.entry = entry;
+    }
+
+    @Override
+    public FileTime lastModifiedTime() {
+        return entry != null
+                ? FileTime.fromMillis(entry.lastModifiedTime())
+                : FileTime.fromMillis(0L);
+    }
+
+    @Override
+    public FileTime lastAccessTime() {
+        return lastModifiedTime();
+    }
+
+    @Override
+    public FileTime creationTime() {
+        return lastModifiedTime();
+    }
+
+    @Override
+    public boolean isRegularFile() {
+        return entry != null && !entry.directory();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return entry == null || entry.directory();
+    }
+
+    @Override
+    public boolean isSymbolicLink() {
+        return false;
+    }
+
+    @Override
+    public boolean isOther() {
+        return false;
+    }
+
+    @Override
+    public long size() {
+        return entry != null ? entry.uncompressedSize() : 0L;
+    }
+
+    /**
+     * @return {@code null}; ZIP entries have no meaningful file key
+     */
+    @Override
+    public Object fileKey() {
+        return null;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileStore.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileStore.java
@@ -1,0 +1,108 @@
+package io.quarkus.fs.util.rozip;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+
+/**
+ * A read-only {@link FileStore} backed by a ZIP archive file.
+ */
+class ReadOnlyZipFileStore extends FileStore {
+
+    private final Path zipPath;
+
+    /**
+     * @param zipPath path to the ZIP archive on the default filesystem
+     */
+    ReadOnlyZipFileStore(Path zipPath) {
+        this.zipPath = zipPath;
+    }
+
+    /**
+     * @return the string form of the archive path
+     */
+    @Override
+    public String name() {
+        return zipPath.toString();
+    }
+
+    /**
+     * @return {@code "zip"}
+     */
+    @Override
+    public String type() {
+        return "zip";
+    }
+
+    /**
+     * @return {@code true} always
+     */
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    /**
+     * @return the size of the ZIP archive file in bytes
+     * @throws IOException if the file size cannot be read
+     */
+    @Override
+    public long getTotalSpace() throws IOException {
+        return Files.size(zipPath);
+    }
+
+    /**
+     * @return {@code 0} always; the archive is read-only
+     */
+    @Override
+    public long getUsableSpace() {
+        return 0;
+    }
+
+    /**
+     * @return {@code 0} always; the archive is read-only
+     */
+    @Override
+    public long getUnallocatedSpace() {
+        return 0;
+    }
+
+    /**
+     * @param type the attribute view class to check
+     * @return {@code true} if {@code type} is {@link BasicFileAttributeView}
+     */
+    @Override
+    public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+        return type == BasicFileAttributeView.class;
+    }
+
+    /**
+     * @param name the attribute view name to check
+     * @return {@code true} if {@code name} is {@code "basic"}
+     */
+    @Override
+    public boolean supportsFileAttributeView(String name) {
+        return "basic".equals(name);
+    }
+
+    /**
+     * @return {@code null} always; no file store attribute views are supported
+     */
+    @Override
+    public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
+        return null;
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; no store-level
+     *         attributes are supported
+     */
+    @Override
+    public Object getAttribute(String attribute) throws IOException {
+        throw new UnsupportedOperationException("Attribute " + attribute + " not supported");
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystem.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystem.java
@@ -1,0 +1,862 @@
+package io.quarkus.fs.util.rozip;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.ref.SoftReference;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.ClosedFileSystemException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+/**
+ * A read-only {@link FileSystem} implementation for ZIP/JAR archives that is
+ * immune to thread-interrupt-induced channel closures.
+ * <p>
+ * Unlike the JDK's {@code ZipFileSystem}, which uses a shared
+ * {@link java.nio.channels.FileChannel} (an {@link java.nio.channels.InterruptibleChannel}),
+ * this implementation reads through a {@link RandomAccessFile} whose I/O
+ * operations are <em>not</em> affected by thread interrupts.
+ * This eliminates the root cause of
+ * <a href="https://bugs.openjdk.org/browse/JDK-8316882">JDK-8316882</a>.
+ * <p>
+ * Entry data is read on demand and decompressed into a byte array. STORED and
+ * DEFLATED compression methods are supported. All reads are synchronized on
+ * the underlying {@link RandomAccessFile} for thread safety.
+ * <p>
+ * Instances are created via the {@link #open(Path)} factory method.
+ *
+ * @see ReadOnlyZipPath
+ * @see ReadOnlyZipFileSystemProvider
+ */
+public class ReadOnlyZipFileSystem extends FileSystem {
+
+    private static final int LOCAL_HEADER_SIG = 0x04034b50;
+    private static final int LOCAL_HEADER_FIXED_SIZE = 30;
+    private static final int DATA_DESCRIPTOR_SIG = 0x08074b50;
+    private static final int METHOD_STORED = 0;
+    private static final int METHOD_DEFLATED = 8;
+
+    static final long MAX_ENTRY_SIZE = 256 * 1024 * 1024L; // 256 MB
+    private static final long MAX_COMPRESSION_RATIO = 1000;
+    static boolean CACHE_ENABLED = Boolean.getBoolean("rozip.cache");
+
+    private final Path zipPath;
+    private final RandomAccessFile raf;
+    private final CompactEntryTable entryTable;
+    private final ReadOnlyZipPath rootPath;
+    private final FileStore fileStore;
+    private final AtomicBoolean open = new AtomicBoolean(true);
+    private static final int MAX_INFLATER_POOL_SIZE = 8;
+    private final Deque<Inflater> inflaterPool = new ArrayDeque<>();
+    private final ConcurrentHashMap<String, SoftReference<byte[]>> entryCache;
+
+    /**
+     * Opens a read-only, non-interruptible filesystem for the given ZIP/JAR file.
+     * <p>
+     * The central directory is parsed immediately. The underlying
+     * {@link RandomAccessFile} remains open until {@link #close()} is called.
+     * <p>
+     * Each invocation opens a new, independent file handle — no caching or
+     * deduplication is performed. Callers that need to avoid duplicate handles
+     * for the same archive should cache the returned instance themselves.
+     *
+     * @param zipFile path to the ZIP or JAR file
+     * @return a new {@link ReadOnlyZipFileSystem} instance
+     * @throws IOException if the file cannot be read or is not a valid ZIP archive
+     */
+    public static ReadOnlyZipFileSystem open(Path zipFile) throws IOException {
+        RandomAccessFile raf = new RandomAccessFile(zipFile.toFile(), "r");
+        try {
+            ZipCentralDirectory cd = ZipCentralDirectory.parse(raf);
+            return new ReadOnlyZipFileSystem(zipFile, raf, cd);
+        } catch (IOException | RuntimeException e) {
+            try {
+                raf.close();
+            } catch (IOException closeEx) {
+                e.addSuppressed(closeEx);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Constructs a new filesystem backed by the given archive file.
+     *
+     * @param zipPath path to the ZIP/JAR file on the default filesystem
+     * @param raf an open file handle for reading entry data
+     * @param cd the parsed central directory
+     */
+    private ReadOnlyZipFileSystem(Path zipPath, RandomAccessFile raf, ZipCentralDirectory cd) {
+        this.zipPath = zipPath;
+        this.raf = raf;
+        this.entryTable = cd.entryTable();
+        this.entryCache = CACHE_ENABLED ? new ConcurrentHashMap<>() : null;
+        this.rootPath = new ReadOnlyZipPath(this, "/");
+        this.fileStore = new ReadOnlyZipFileStore(zipPath);
+    }
+
+    /**
+     * @return the singleton {@link ReadOnlyZipFileSystemProvider}
+     */
+    @Override
+    public FileSystemProvider provider() {
+        return ReadOnlyZipFileSystemProvider.INSTANCE;
+    }
+
+    /**
+     * Closes this filesystem and releases the underlying file handle.
+     * <p>
+     * After closing, all operations on paths from this filesystem will throw
+     * {@link ClosedFileSystemException}. This method is idempotent.
+     */
+    @Override
+    public void close() throws IOException {
+        if (open.compareAndSet(true, false)) {
+            synchronized (raf) {
+                raf.close();
+            }
+            synchronized (inflaterPool) {
+                Inflater inf;
+                while ((inf = inflaterPool.poll()) != null) {
+                    inf.end();
+                }
+            }
+            if (entryCache != null) {
+                entryCache.clear();
+            }
+        }
+    }
+
+    /**
+     * @return {@code true} if this filesystem has not been {@linkplain #close() closed}
+     */
+    @Override
+    public boolean isOpen() {
+        return open.get();
+    }
+
+    /**
+     * @return {@code true} always; this filesystem does not support write operations
+     */
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    /**
+     * @return {@code "/"}, the path separator for ZIP entries
+     */
+    @Override
+    public String getSeparator() {
+        return "/";
+    }
+
+    /**
+     * @return a single-element iterable containing the root path {@code "/"}
+     */
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return Collections.singletonList(rootPath);
+    }
+
+    /**
+     * @return a single-element iterable containing this archive's {@link FileStore}
+     */
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return Collections.singletonList(fileStore);
+    }
+
+    /**
+     * @return the {@link FileStore} representing this archive
+     */
+    FileStore getFileStore() {
+        return fileStore;
+    }
+
+    /**
+     * @return a set containing only {@code "basic"}
+     */
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        return Set.of("basic");
+    }
+
+    /**
+     * Creates a {@link ReadOnlyZipPath} by joining the given strings with
+     * the {@code "/"} separator.
+     *
+     * @param first the first component
+     * @param more additional components to join
+     * @return a new path in this filesystem
+     */
+    @Override
+    public Path getPath(String first, String... more) {
+        ensureOpen();
+        if (more.length == 0) {
+            return new ReadOnlyZipPath(this, first);
+        }
+        StringBuilder sb = new StringBuilder(first);
+        for (String s : more) {
+            if (!sb.isEmpty() && sb.charAt(sb.length() - 1) != '/') {
+                sb.append('/');
+            }
+            sb.append(s);
+        }
+        return new ReadOnlyZipPath(this, sb.toString());
+    }
+
+    /**
+     * Returns a {@link PathMatcher} for the given syntax and pattern.
+     * Supports {@code "glob:..."} and {@code "regex:..."} syntaxes.
+     *
+     * @param syntaxAndPattern the syntax and pattern string (e.g. {@code "glob:*.class"})
+     * @return a path matcher
+     * @throws IllegalArgumentException if the syntax is not supported
+     * @throws java.util.regex.PatternSyntaxException if the pattern is invalid
+     */
+    @Override
+    public PathMatcher getPathMatcher(String syntaxAndPattern) {
+        int colon = syntaxAndPattern.indexOf(':');
+        if (colon <= 0 || colon == syntaxAndPattern.length() - 1) {
+            throw new IllegalArgumentException("Invalid syntax: " + syntaxAndPattern);
+        }
+        String syntax = syntaxAndPattern.substring(0, colon).toLowerCase();
+        String pattern = syntaxAndPattern.substring(colon + 1);
+
+        Pattern regex;
+        if ("regex".equals(syntax)) {
+            regex = Pattern.compile(pattern);
+        } else if ("glob".equals(syntax)) {
+            regex = Pattern.compile(globToRegex(pattern));
+        } else {
+            throw new UnsupportedOperationException("Syntax '" + syntax + "' not supported");
+        }
+        return path -> regex.matcher(path.toString()).matches();
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; ZIP archives have no user
+     *         principal lookup service
+     */
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService() {
+        throw new UnsupportedOperationException("UserPrincipalLookupService not supported");
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; ZIP archives cannot be
+     *         watched for changes
+     */
+    @Override
+    public WatchService newWatchService() throws IOException {
+        throw new UnsupportedOperationException("WatchService not supported");
+    }
+
+    /**
+     * @return the string form of the path to the underlying ZIP file
+     */
+    @Override
+    public String toString() {
+        return zipPath.toString();
+    }
+
+    /**
+     * @return the cached root path {@code "/"}
+     */
+    ReadOnlyZipPath getRootPath() {
+        return rootPath;
+    }
+
+    /**
+     * @return the path to the underlying ZIP file on the default filesystem
+     */
+    Path getZipPath() {
+        return zipPath;
+    }
+
+    /**
+     * Constructs a {@code jar:} URI for an entry within this archive.
+     *
+     * @param absoluteEntryPath the absolute entry path (e.g. {@code "/com/example/Foo.class"})
+     * @return a URI of the form {@code jar:file:///path/to/archive.jar!/entry/path}
+     */
+    URI entryUri(String absoluteEntryPath) {
+        try {
+            String encoded = new URI(null, null, absoluteEntryPath, null).getRawPath();
+            return URI.create("jar:" + zipPath.toUri() + "!" + encoded);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid entry path: " + absoluteEntryPath, e);
+        }
+    }
+
+    /**
+     * Looks up entry metadata by name.
+     *
+     * @param entryName the entry name without leading {@code "/"} (empty string
+     *        for root)
+     * @return the entry info, or {@code null} if not found
+     */
+    ZipEntryInfo getEntryInfo(String entryName) {
+        ensureOpen();
+        return ZipEntryInfo.ROOT_ENTRY_NAME.equals(entryName) ? null : entryTable.getEntry(entryName);
+    }
+
+    /**
+     * Returns the immediate children of a directory entry.
+     *
+     * @param entryName the directory entry name (empty string for root)
+     * @return the list of child names, or {@code null} if not a directory
+     */
+    List<String> getDirectoryChildren(String entryName) {
+        ensureOpen();
+        return entryTable.getDirectoryChildren(entryName);
+    }
+
+    /**
+     * Checks whether the given entry name exists (either as a file, an
+     * explicit directory, an implicit directory, or the root).
+     *
+     * @param entryName the entry name
+     * @return {@code true} if the entry exists
+     */
+    public boolean entryExists(String entryName) {
+        ensureOpen();
+        entryName = normalizeEntryName(entryName);
+        return entryName.isEmpty() || entryTable.exists(entryName);
+    }
+
+    /**
+     * Strips a leading and/or trailing {@code '/'} from an entry name,
+     * converting path-style names (e.g. {@code "/com/example/"}) to the
+     * slash-free form used by {@link CompactEntryTable} (e.g.
+     * {@code "com/example"}). Returns the empty string for the root
+     * ({@code "/"} or {@code ""}).
+     */
+    static String normalizeEntryName(String name) {
+        if (name.isEmpty()) {
+            return name;
+        }
+        if (name.charAt(0) == '/') {
+            if (name.length() == 1) {
+                return ZipEntryInfo.ROOT_ENTRY_NAME;
+            }
+            return name.charAt(name.length() - 1) == '/' ? name.substring(1, name.length() - 1) : name.substring(1);
+        }
+        return name.charAt(name.length() - 1) == '/' ? name.substring(0, name.length() - 1) : name;
+    }
+
+    /**
+     * Returns {@link BasicFileAttributes} for the given entry name.
+     *
+     * @param entryName the entry name (empty string for root)
+     * @return the attributes
+     * @throws NoSuchFileException if the entry does not exist
+     */
+    BasicFileAttributes getAttributes(String entryName) throws NoSuchFileException {
+        ensureOpen();
+        if (ZipEntryInfo.ROOT_ENTRY_NAME.equals(entryName)) {
+            return ReadOnlyZipAttributes.ROOT;
+        }
+        ZipEntryInfo info = entryTable.getEntry(entryName);
+        if (info != null) {
+            return new ReadOnlyZipAttributes(info);
+        }
+        if (entryTable.hasEntriesUnder(entryName)) {
+            return ReadOnlyZipAttributes.ROOT;
+        }
+        throw new NoSuchFileException(entryName);
+    }
+
+    /**
+     * Reads and decompresses the data for the given entry.
+     * <p>
+     * The compressed bytes are read from the underlying {@link RandomAccessFile}
+     * within a synchronized block. If the entry uses DEFLATED compression, the
+     * data is decompressed using {@link Inflater} before being returned.
+     *
+     * @param entryName the entry name
+     * @return the uncompressed entry data
+     * @throws NoSuchFileException if the entry does not exist
+     * @throws IOException if the entry is a directory or an I/O error occurs
+     */
+    byte[] readEntryData(String entryName) throws IOException {
+        ensureOpen();
+        ZipEntryInfo info = entryTable.getEntry(entryName);
+        if (info == null) {
+            if (entryTable.hasEntriesUnder(entryName)) {
+                throw new FileSystemException(entryName, null, "is a directory");
+            }
+            throw new NoSuchFileException(entryName);
+        }
+        if (info.directory()) {
+            throw new FileSystemException(entryName, null, "is a directory");
+        }
+
+        if (entryCache != null) {
+            SoftReference<byte[]> ref = entryCache.get(entryName);
+            if (ref != null) {
+                byte[] cached = ref.get();
+                if (cached != null) {
+                    return cached;
+                }
+            }
+        }
+
+        validateEntrySize(info);
+        CompressedEntry ce = readCompressedData(info);
+        byte[] result = decompress(ce, info);
+        if (entryCache != null) {
+            entryCache.put(entryName, new SoftReference<>(result));
+        }
+        return result;
+    }
+
+    /**
+     * Holds the compressed bytes read from the archive together with the
+     * best-known uncompressed size resolved from the local file header or
+     * data descriptor.
+     *
+     * @param data the raw (possibly compressed) entry bytes
+     * @param uncompressedSize uncompressed size from the local header or data
+     *        descriptor, or 0 if neither source provided it
+     */
+    private record CompressedEntry(byte[] data, long uncompressedSize) {
+    }
+
+    /**
+     * Reads the compressed data bytes for an entry from the archive.
+     * <p>
+     * Seeks to the local file header, reads it to determine the actual data
+     * offset (which may differ from the central directory due to differing
+     * extra field lengths), then reads the compressed data.
+     * <p>
+     * Also resolves the uncompressed size when the central directory reports 0.
+     * The local header (offset 22) is checked first. If it is also 0 and the
+     * general-purpose bit 3 is set (data descriptor present), the data
+     * descriptor immediately following the compressed data is read to obtain
+     * the actual uncompressed size. This lets {@link #decompress} use the
+     * efficient pre-allocated inflate path in virtually all cases.
+     *
+     * @param info the entry metadata from the central directory
+     * @return compressed bytes together with the resolved uncompressed size
+     * @throws IOException if the file cannot be read or the local header is invalid
+     */
+    private CompressedEntry readCompressedData(ZipEntryInfo info) throws IOException {
+        // ensureOpen inside synchronized(raf) guarantees the file handle cannot
+        // be closed between the check and the reads — close() also syncs on raf
+        synchronized (raf) {
+            ensureOpen();
+            raf.seek(info.localHeaderOffset());
+            byte[] localHeader = new byte[LOCAL_HEADER_FIXED_SIZE];
+            raf.readFully(localHeader);
+            validateLocalHeader(localHeader, info);
+
+            long localUncompressedSize = LittleEndian.readUint32(localHeader, 22);
+            int nameLen = LittleEndian.readUint16(localHeader, 26);
+            int extraLen = LittleEndian.readUint16(localHeader, 28);
+            long dataOffset = info.localHeaderOffset() + LOCAL_HEADER_FIXED_SIZE + nameLen + extraLen;
+
+            raf.seek(dataOffset);
+            byte[] compressed = new byte[checkedCast(info.compressedSize())];
+            raf.readFully(compressed);
+
+            long uncompressedSize = localUncompressedSize;
+            if (uncompressedSize == 0 && info.uncompressedSize() == 0) {
+                int flags = LittleEndian.readUint16(localHeader, 6);
+                if ((flags & 0x08) != 0) {
+                    boolean zip64 = LittleEndian.readUint16(localHeader, 4) >= 45;
+                    uncompressedSize = readDataDescriptorUncompressedSize(zip64);
+                }
+            }
+
+            return new CompressedEntry(compressed, uncompressedSize);
+        }
+    }
+
+    /**
+     * Reads the uncompressed size from a data descriptor at the current
+     * file position. Handles both the variant with a leading signature
+     * ({@code 0x08074b50}) and the variant without, and both 32-bit and
+     * 64-bit (ZIP64) field sizes.
+     *
+     * @param zip64 {@code true} if the entry uses ZIP64 format (8-byte fields)
+     * @return the uncompressed size from the data descriptor
+     * @throws IOException if the descriptor cannot be read
+     */
+    private long readDataDescriptorUncompressedSize(boolean zip64) throws IOException {
+        if (zip64) {
+            // ZIP64: signature?(4) + crc32(4) + compressedSize(8) + uncompressedSize(8)
+            byte[] desc = new byte[24];
+            raf.readFully(desc);
+            if (LittleEndian.readInt32(desc, 0) == DATA_DESCRIPTOR_SIG) {
+                return LittleEndian.readUint64(desc, 16);
+            }
+            // no signature: crc32(4) + compressedSize(8) + uncompressedSize(8)
+            // we read 24 bytes but only need 20; the last 4 are unused
+            return LittleEndian.readUint64(desc, 12);
+        }
+        byte[] desc = new byte[16];
+        raf.readFully(desc);
+        if (LittleEndian.readInt32(desc, 0) == DATA_DESCRIPTOR_SIG) {
+            // signature(4) + crc32(4) + compressedSize(4) + uncompressedSize(4)
+            return LittleEndian.readUint32(desc, 12);
+        }
+        // no signature: crc32(4) + compressedSize(4) + uncompressedSize(4)
+        return LittleEndian.readUint32(desc, 8);
+    }
+
+    /**
+     * Validates the local file header signature.
+     */
+    private static void validateLocalHeader(byte[] header, ZipEntryInfo info) throws IOException {
+        int sig = LittleEndian.readInt32(header, 0);
+        if (sig != LOCAL_HEADER_SIG) {
+            throw new IOException("Invalid local file header signature for entry: " + info.name());
+        }
+    }
+
+    /**
+     * Decompresses entry data according to its compression method.
+     * <p>
+     * For DEFLATED entries, uses the uncompressed size from the central
+     * directory when available, otherwise falls back to the size resolved
+     * by {@link #readCompressedData} (from the local header or data
+     * descriptor). Genuinely empty entries (uncompressed size and CRC both
+     * 0) are returned immediately without inflating.
+     *
+     * @param ce the compressed bytes and resolved uncompressed size
+     * @param info the entry metadata from the central directory
+     * @return the uncompressed bytes
+     * @throws IOException if decompression fails or the method is unsupported
+     */
+    private byte[] decompress(CompressedEntry ce, ZipEntryInfo info) throws IOException {
+        byte[] result;
+        if (info.compressionMethod() == METHOD_STORED) {
+            result = ce.data();
+        } else if (info.compressionMethod() == METHOD_DEFLATED) {
+            long uncompressedSize = info.uncompressedSize();
+            if (uncompressedSize == 0 && ce.uncompressedSize() > 0) {
+                uncompressedSize = ce.uncompressedSize();
+            }
+            if (uncompressedSize > MAX_ENTRY_SIZE) {
+                throw new IOException("Entry too large (uncompressed " + uncompressedSize
+                        + " bytes, limit " + MAX_ENTRY_SIZE + "): " + info.name());
+            }
+            if (uncompressedSize == 0 && info.crc32() == 0) {
+                return new byte[0];
+            }
+            result = inflate(ce.data(), checkedCast(uncompressedSize));
+        } else {
+            throw new IOException("Unsupported compression method " + info.compressionMethod()
+                    + " for entry: " + info.name());
+        }
+        verifyCrc32(result, info);
+        return result;
+    }
+
+    /**
+     * Validates that the entry's compressed and uncompressed sizes are within
+     * limits and that the compression ratio is not suspiciously high.
+     *
+     * @param info the entry metadata
+     * @throws IOException if any size check fails
+     */
+    private static void validateEntrySize(ZipEntryInfo info) throws IOException {
+        if (info.uncompressedSize() > MAX_ENTRY_SIZE) {
+            throw new IOException("Entry too large (uncompressed " + info.uncompressedSize()
+                    + " bytes, limit " + MAX_ENTRY_SIZE + "): " + info.name());
+        }
+        if (info.compressedSize() > MAX_ENTRY_SIZE) {
+            throw new IOException("Entry too large (compressed " + info.compressedSize()
+                    + " bytes, limit " + MAX_ENTRY_SIZE + "): " + info.name());
+        }
+        if (info.compressedSize() > 0
+                && info.uncompressedSize() / info.compressedSize() > MAX_COMPRESSION_RATIO) {
+            throw new IOException("Suspicious compression ratio for entry: " + info.name());
+        }
+    }
+
+    /**
+     * Verifies that the CRC-32 of the decompressed data matches the value
+     * recorded in the central directory.
+     *
+     * @param data the decompressed entry bytes
+     * @param info the entry metadata containing the expected CRC-32
+     * @throws IOException if the checksums do not match
+     */
+    private static void verifyCrc32(byte[] data, ZipEntryInfo info) throws IOException {
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        if (crc.getValue() != info.crc32()) {
+            throw new IOException("CRC-32 mismatch for entry: " + info.name()
+                    + " (expected " + Long.toHexString(info.crc32())
+                    + ", got " + Long.toHexString(crc.getValue()) + ")");
+        }
+    }
+
+    /**
+     * Inflates DEFLATE-compressed data into a pre-allocated buffer.
+     * <p>
+     * When {@code uncompressedSize} is 0 (unknown), delegates to
+     * {@link #inflateDynamic(byte[])} which uses a dynamically-growing buffer.
+     *
+     * @param compressed the raw DEFLATE-compressed bytes
+     * @param uncompressedSize the expected decompressed size, or 0 if unknown
+     * @return the decompressed bytes
+     * @throws IOException if decompression fails or the actual size does not
+     *         match the declared size
+     */
+    private byte[] inflate(byte[] compressed, int uncompressedSize) throws IOException {
+        if (uncompressedSize == 0) {
+            // this shouldn't happen for a spec compliant ZIP, this is a defensive measure
+            // matching the default ZipFileSystem implementation
+            return inflateDynamic(compressed);
+        }
+        Inflater inflater = borrowInflater();
+        try {
+            inflater.setInput(compressed);
+            byte[] result = new byte[uncompressedSize];
+            int offset = 0;
+            while (offset < uncompressedSize) {
+                int n = inflater.inflate(result, offset, uncompressedSize - offset);
+                if (n == 0) {
+                    if (inflater.finished() || inflater.needsDictionary()) {
+                        break;
+                    }
+                    throw new IOException("Inflater stalled; compressed data may be corrupt");
+                }
+                offset += n;
+            }
+            if (offset < uncompressedSize) {
+                throw new IOException("Decompressed size (" + offset
+                        + ") is less than declared (" + uncompressedSize + ")");
+            }
+            if (!inflater.finished()) {
+                throw new IOException("Decompressed data exceeds declared size (" + uncompressedSize + ")");
+            }
+            return result;
+        } catch (DataFormatException e) {
+            throw new IOException("Failed to decompress entry data", e);
+        } finally {
+            returnInflater(inflater);
+        }
+    }
+
+    /**
+     * Inflates compressed data when the uncompressed size is unknown (reported
+     * as 0 in both the central directory and local file header). This occurs
+     * with entries written using data descriptors, where some ZIP tools omit
+     * sizes from both headers.
+     * <p>
+     * Inflates directly into a dynamically-growing {@code byte[]} rather than
+     * through a {@link java.io.ByteArrayOutputStream} with an intermediate
+     * buffer, so each decompressed byte is written once into the result array
+     * instead of being copied twice (intermediate buffer to BAOS, then
+     * {@code toByteArray()}). Output is capped at {@link #MAX_ENTRY_SIZE} to
+     * guard against zip bombs.
+     *
+     * @param compressed the raw DEFLATE-compressed bytes
+     * @return the decompressed bytes
+     * @throws IOException if decompression fails or the output exceeds {@link #MAX_ENTRY_SIZE}
+     */
+    private byte[] inflateDynamic(byte[] compressed) throws IOException {
+        Inflater inflater = borrowInflater();
+        try {
+            inflater.setInput(compressed);
+            int capacity = Math.max(compressed.length * 2, 256);
+            byte[] result = new byte[capacity];
+            int offset = 0;
+            while (!inflater.finished()) {
+                if (offset == result.length) {
+                    int newCap = (int) Math.min((long) result.length * 2, MAX_ENTRY_SIZE + 1);
+                    result = Arrays.copyOf(result, newCap);
+                }
+                int n = inflater.inflate(result, offset, result.length - offset);
+                if (n == 0) {
+                    if (inflater.finished() || inflater.needsDictionary()) {
+                        break;
+                    }
+                    throw new IOException("Inflater stalled; compressed data may be corrupt");
+                }
+                offset += n;
+                if (offset > MAX_ENTRY_SIZE) {
+                    throw new IOException("Decompressed data exceeds maximum entry size (" + MAX_ENTRY_SIZE + ")");
+                }
+            }
+            return (offset == result.length) ? result : Arrays.copyOf(result, offset);
+        } catch (DataFormatException e) {
+            throw new IOException("Failed to decompress entry data", e);
+        } finally {
+            returnInflater(inflater);
+        }
+    }
+
+    /**
+     * Returns a pooled {@link Inflater} configured for raw DEFLATE (no
+     * zlib header), or creates a new one if the pool is empty.
+     *
+     * @return an {@link Inflater} ready for use
+     */
+    private Inflater borrowInflater() {
+        synchronized (inflaterPool) {
+            Inflater inf = inflaterPool.poll();
+            if (inf != null) {
+                return inf;
+            }
+        }
+        return new Inflater(true);
+    }
+
+    /**
+     * Returns an {@link Inflater} to the pool after use. If the filesystem
+     * is closed or the pool is full, the inflater is ended instead.
+     *
+     * @param inf the inflater to return
+     */
+    private void returnInflater(Inflater inf) {
+        synchronized (inflaterPool) {
+            if (open.get() && inflaterPool.size() < MAX_INFLATER_POOL_SIZE) {
+                inf.reset();
+                inflaterPool.push(inf);
+                return;
+            }
+        }
+        inf.end();
+    }
+
+    /**
+     * @throws ClosedFileSystemException if this filesystem has been closed
+     */
+    private void ensureOpen() {
+        if (!open.get()) {
+            throw new ClosedFileSystemException();
+        }
+    }
+
+    /**
+     * Safely casts a {@code long} to {@code int}, throwing if the value
+     * exceeds {@link Integer#MAX_VALUE}.
+     */
+    private static int checkedCast(long value) throws IOException {
+        if (value < 0 || value > Integer.MAX_VALUE) {
+            throw new IOException("Entry size too large: " + value);
+        }
+        return (int) value;
+    }
+
+    /**
+     * Converts a glob pattern to a Java regex pattern.
+     * <p>
+     * Supported glob constructs:
+     * <ul>
+     * <li>{@code *} — matches zero or more characters within a single path segment</li>
+     * <li>{@code **} — matches zero or more path segments (crosses {@code /} boundaries)</li>
+     * <li>{@code ?} — matches exactly one non-separator character</li>
+     * <li>{@code [abc]} — character class matching any one of the enclosed characters</li>
+     * <li>{@code {a,b}} — brace alternation, may be nested (e.g. {@code {a,{b,c}}})</li>
+     * <li>{@code \x} — escapes the next character, treating it as a literal</li>
+     * </ul>
+     * Regex metacharacters ({@code . ( ) + | ^ $ @ %}) are escaped automatically.
+     *
+     * @param glob the glob pattern to convert
+     * @return a regex string anchored with {@code ^} and {@code $}
+     */
+    static String globToRegex(String glob) {
+        StringBuilder regex = new StringBuilder("^");
+        int i = 0;
+        int braceDepth = 0;
+        while (i < glob.length()) {
+            char c = glob.charAt(i);
+            switch (c) {
+                case '*':
+                    if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                        i += 2;
+                        if (i < glob.length() && glob.charAt(i) == '/') {
+                            regex.append("(.*/)?");
+                            i++;
+                        } else {
+                            regex.append(".+");
+                        }
+                    } else {
+                        regex.append("[^/]*");
+                        i++;
+                    }
+                    break;
+                case '?':
+                    regex.append("[^/]");
+                    i++;
+                    break;
+                case '[':
+                    regex.append('[');
+                    i++;
+                    if (i < glob.length() && glob.charAt(i) == '!') {
+                        regex.append('^');
+                        i++;
+                    }
+                    while (i < glob.length() && glob.charAt(i) != ']') {
+                        regex.append(glob.charAt(i));
+                        i++;
+                    }
+                    if (i < glob.length()) {
+                        regex.append(']');
+                        i++;
+                    }
+                    break;
+                case '{':
+                    regex.append('(');
+                    braceDepth++;
+                    i++;
+                    break;
+                case '}':
+                    regex.append(')');
+                    braceDepth--;
+                    i++;
+                    break;
+                case ',':
+                    regex.append(braceDepth > 0 ? '|' : ',');
+                    i++;
+                    break;
+                case '\\':
+                    if (i + 1 < glob.length()) {
+                        regex.append('\\').append(glob.charAt(i + 1));
+                        i += 2;
+                    } else {
+                        regex.append('\\');
+                        i++;
+                    }
+                    break;
+                default:
+                    if (".()+|^$@%".indexOf(c) >= 0) {
+                        regex.append('\\');
+                    }
+                    regex.append(c);
+                    i++;
+                    break;
+            }
+        }
+        regex.append('$');
+        return regex.toString();
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystemProvider.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystemProvider.java
@@ -1,0 +1,607 @@
+package io.quarkus.fs.util.rozip;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.ReadOnlyFileSystemException;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link FileSystemProvider} for the read-only, non-interruptible ZIP filesystem.
+ * <p>
+ * This provider is <em>not</em> registered via {@link java.util.ServiceLoader};
+ * it is only used programmatically through {@link ReadOnlyZipFileSystem#open(Path)}.
+ * Each {@link ReadOnlyZipFileSystem} instance references a shared singleton of
+ * this provider.
+ * <p>
+ * All write operations throw {@link ReadOnlyFileSystemException}.
+ */
+class ReadOnlyZipFileSystemProvider extends FileSystemProvider {
+
+    static final ReadOnlyZipFileSystemProvider INSTANCE = new ReadOnlyZipFileSystemProvider();
+
+    private ReadOnlyZipFileSystemProvider() {
+    }
+
+    /**
+     * Returns {@code "jar"} to stay consistent with the JDK's ZIP filesystem
+     * provider. This ensures that URIs produced by {@link ReadOnlyZipPath#toUri()}
+     * use the standard {@code jar:file:///...} form and are recognizable by code
+     * that inspects URI schemes. Because this provider is not registered via
+     * {@link java.util.ServiceLoader}, the scheme is never used for provider lookup.
+     *
+     * @return {@code "jar"}
+     */
+    @Override
+    public String getScheme() {
+        return "jar";
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; use
+     *         {@link ReadOnlyZipFileSystem#open(Path)} instead
+     */
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+        throw new UnsupportedOperationException("Use ReadOnlyZipFileSystem.open(Path)");
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; use
+     *         {@link ReadOnlyZipFileSystem#open(Path)} instead
+     */
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        throw new UnsupportedOperationException("Use ReadOnlyZipFileSystem.open(Path)");
+    }
+
+    /**
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public Path getPath(URI uri) {
+        throw new UnsupportedOperationException("Use ReadOnlyZipFileSystem.getPath(String)");
+    }
+
+    /**
+     * Opens an {@link InputStream} to read the contents of the specified entry.
+     * <p>
+     * The entire entry is read and decompressed (if needed) into a byte array.
+     * The returned stream reads from that array, so it does not hold any lock
+     * on the underlying ZIP file.
+     *
+     * @param path the entry path
+     * @param options open options (only {@link StandardOpenOption#READ} is accepted)
+     * @return an input stream for reading the entry contents
+     * @throws NoSuchFileException if the entry does not exist
+     * @throws IOException if the entry is a directory or an I/O error occurs
+     */
+    @Override
+    public InputStream newInputStream(Path path, OpenOption... options) throws IOException {
+        validateReadOptions(options);
+        ReadOnlyZipFileSystem fs = toFs(path);
+        String entryName = toEntryName(path);
+        byte[] data = fs.readEntryData(entryName);
+        return new ByteArrayInputStream(data);
+    }
+
+    /**
+     * @throws ReadOnlyFileSystemException always
+     */
+    @Override
+    public OutputStream newOutputStream(Path path, OpenOption... options) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    /**
+     * Opens a {@link SeekableByteChannel} to read the contents of the specified
+     * entry.
+     *
+     * @param path the entry path
+     * @param options open options (only {@link StandardOpenOption#READ} is accepted)
+     * @param attrs ignored
+     * @return a seekable byte channel over the entry contents
+     * @throws NoSuchFileException if the entry does not exist
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs) throws IOException {
+        validateReadOptions(options);
+        ReadOnlyZipFileSystem fs = toFs(path);
+        String entryName = toEntryName(path);
+        byte[] data = fs.readEntryData(entryName);
+        return new ByteArrayChannel(data);
+    }
+
+    /**
+     * Returns a {@link DirectoryStream} that iterates over the immediate
+     * children of the given directory entry.
+     *
+     * @param dir the directory path
+     * @param filter the filter to apply to each child
+     * @return a directory stream of child paths
+     * @throws NoSuchFileException if the directory does not exist
+     * @throws IOException if the path is not a directory
+     */
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir,
+            DirectoryStream.Filter<? super Path> filter) throws IOException {
+        ReadOnlyZipFileSystem fs = toFs(dir);
+        String entryName = toEntryName(dir);
+        List<String> children = fs.getDirectoryChildren(entryName);
+        if (children == null) {
+            ZipEntryInfo info = fs.getEntryInfo(entryName);
+            if (info == null) {
+                throw new NoSuchFileException(dir.toString());
+            }
+            throw new IOException("Not a directory: " + dir);
+        }
+
+        Path parent = ((ReadOnlyZipPath) dir).toAbsolutePath();
+        return new DirectoryStream<>() {
+            private volatile boolean open = true;
+            private final AtomicBoolean iteratorReturned = new AtomicBoolean();
+
+            @Override
+            public Iterator<Path> iterator() {
+                if (!open) {
+                    throw new IllegalStateException("DirectoryStream is closed");
+                }
+                if (!iteratorReturned.compareAndSet(false, true)) {
+                    throw new IllegalStateException("Iterator already obtained");
+                }
+                return new FilteredChildIterator(parent, children, filter, fs);
+            }
+
+            @Override
+            public void close() throws IOException {
+                open = false;
+            }
+        };
+    }
+
+    /**
+     * Reads basic file attributes for the given path.
+     *
+     * @param path the entry path
+     * @param type must be {@link BasicFileAttributes}{@code .class}
+     * @param options ignored (no symlinks in ZIP)
+     * @return the file attributes
+     * @throws NoSuchFileException if the entry does not exist
+     * @throws UnsupportedOperationException if {@code type} is not
+     *         {@code BasicFileAttributes.class}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type,
+            LinkOption... options) throws IOException {
+        if (type != BasicFileAttributes.class) {
+            throw new UnsupportedOperationException("Only BasicFileAttributes is supported");
+        }
+        ReadOnlyZipFileSystem fs = toFs(path);
+        String entryName = toEntryName(path);
+        return (A) fs.getAttributes(entryName);
+    }
+
+    /**
+     * Reads file attributes as a name-value map.
+     *
+     * @param path the entry path
+     * @param attributes a comma-separated list of attribute names (e.g. {@code "basic:size,isDirectory"})
+     * @param options ignored
+     * @return a map of attribute names to values
+     * @throws NoSuchFileException if the entry does not exist
+     */
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes,
+            LinkOption... options) throws IOException {
+        BasicFileAttributes attrs = readAttributes(path, BasicFileAttributes.class, options);
+        return attributesToMap(attrs, attributes);
+    }
+
+    /**
+     * Checks that the given entry exists and that the requested access modes
+     * are compatible with a read-only filesystem.
+     *
+     * @param path the entry path
+     * @param modes the access modes to check
+     * @throws NoSuchFileException if the entry does not exist
+     * @throws AccessDeniedException if {@link AccessMode#WRITE} is requested
+     */
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        for (AccessMode mode : modes) {
+            if (mode == AccessMode.WRITE) {
+                throw new AccessDeniedException(path.toString(), null, "Read-only filesystem");
+            }
+        }
+        ReadOnlyZipFileSystem fs = toFs(path);
+        String entryName = toEntryName(path);
+        if (!fs.entryExists(entryName)) {
+            throw new NoSuchFileException(path.toString());
+        }
+    }
+
+    /**
+     * Returns a {@link BasicFileAttributeView} for the given path if requested.
+     *
+     * @param path the entry path
+     * @param type must be {@link BasicFileAttributeView}{@code .class}
+     * @param options ignored
+     * @return the attribute view, or {@code null} if the type is not supported
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type,
+            LinkOption... options) {
+        if (type != BasicFileAttributeView.class) {
+            return null;
+        }
+        return (V) new ReadOnlyBasicFileAttributeView(path, this);
+    }
+
+    @Override
+    public boolean isSameFile(Path path, Path path2) throws IOException {
+        if (path.equals(path2)) {
+            return true;
+        }
+        if (!(path instanceof ReadOnlyZipPath) || !(path2 instanceof ReadOnlyZipPath)) {
+            return false;
+        }
+        ReadOnlyZipFileSystem fs1 = toFs(path);
+        ReadOnlyZipFileSystem fs2 = toFs(path2);
+        if (fs1 != fs2 && !fs1.getZipPath().toRealPath().equals(fs2.getZipPath().toRealPath())) {
+            return false;
+        }
+        return toEntryName(path).equals(toEntryName(path2));
+    }
+
+    @Override
+    public boolean isHidden(Path path) {
+        return false;
+    }
+
+    @Override
+    public java.nio.file.FileStore getFileStore(Path path) throws IOException {
+        return toFs(path).getFileStore();
+    }
+
+    /** @throws ReadOnlyFileSystemException always */
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    /** @throws ReadOnlyFileSystemException always */
+    @Override
+    public void delete(Path path) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    /** @throws ReadOnlyFileSystemException always */
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    /** @throws ReadOnlyFileSystemException always */
+    @Override
+    public void move(Path source, Path target, CopyOption... options) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    /** @throws ReadOnlyFileSystemException always */
+    @Override
+    public void setAttribute(Path path, String attribute, Object value,
+            LinkOption... options) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    /**
+     * Extracts the {@link ReadOnlyZipFileSystem} from the given path.
+     */
+    private static ReadOnlyZipFileSystem toFs(Path path) {
+        return (ReadOnlyZipFileSystem) path.getFileSystem();
+    }
+
+    /**
+     * Converts a {@link ReadOnlyZipPath} to the internal entry name used by
+     * the filesystem index. Strips the leading {@code "/"} from absolute paths
+     * and normalizes directory names.
+     *
+     * @param path the path
+     * @return the entry name (e.g. {@code "com/example/Foo.class"} or {@code ""}
+     *         for root)
+     */
+    private static String toEntryName(Path path) {
+        return ReadOnlyZipFileSystem.normalizeEntryName(path.toAbsolutePath().normalize().toString());
+    }
+
+    /**
+     * Validates that the given open options are compatible with read-only access.
+     *
+     * @throws ReadOnlyFileSystemException if any write option is present
+     */
+    private static void validateReadOptions(OpenOption... options) {
+        validateReadOptions(List.of(options));
+    }
+
+    /**
+     * Validates that the given open option set is compatible with read-only access.
+     *
+     * @throws ReadOnlyFileSystemException if any write option is present
+     */
+    private static void validateReadOptions(Iterable<? extends OpenOption> options) {
+        for (OpenOption opt : options) {
+            if (opt == StandardOpenOption.WRITE
+                    || opt == StandardOpenOption.APPEND
+                    || opt == StandardOpenOption.TRUNCATE_EXISTING
+                    || opt == StandardOpenOption.CREATE
+                    || opt == StandardOpenOption.CREATE_NEW) {
+                throw new ReadOnlyFileSystemException();
+            }
+        }
+    }
+
+    /**
+     * Converts {@link BasicFileAttributes} to a name-value map based on the
+     * requested attribute string.
+     */
+    private static Map<String, Object> attributesToMap(BasicFileAttributes attrs, String spec) {
+        String prefix = "";
+        String names = spec;
+        int colon = spec.indexOf(':');
+        if (colon >= 0) {
+            prefix = spec.substring(0, colon);
+            names = spec.substring(colon + 1);
+        }
+        if (!prefix.isEmpty() && !prefix.equals("basic")) {
+            throw new UnsupportedOperationException("View '" + prefix + "' not supported");
+        }
+
+        if (names.equals("*")) {
+            Map<String, Object> map = new HashMap<>(9);
+            map.put("lastModifiedTime", attrs.lastModifiedTime());
+            map.put("lastAccessTime", attrs.lastAccessTime());
+            map.put("creationTime", attrs.creationTime());
+            map.put("isRegularFile", attrs.isRegularFile());
+            map.put("isDirectory", attrs.isDirectory());
+            map.put("isSymbolicLink", attrs.isSymbolicLink());
+            map.put("isOther", attrs.isOther());
+            map.put("size", attrs.size());
+            map.put("fileKey", attrs.fileKey());
+            return map;
+        }
+        String[] requested = names.split(",");
+        Map<String, Object> map = new HashMap<>(requested.length * 2);
+        for (String name : requested) {
+            name = name.trim();
+            switch (name) {
+                case "lastModifiedTime":
+                    map.put(name, attrs.lastModifiedTime());
+                    break;
+                case "lastAccessTime":
+                    map.put(name, attrs.lastAccessTime());
+                    break;
+                case "creationTime":
+                    map.put(name, attrs.creationTime());
+                    break;
+                case "isRegularFile":
+                    map.put(name, attrs.isRegularFile());
+                    break;
+                case "isDirectory":
+                    map.put(name, attrs.isDirectory());
+                    break;
+                case "isSymbolicLink":
+                    map.put(name, attrs.isSymbolicLink());
+                    break;
+                case "isOther":
+                    map.put(name, attrs.isOther());
+                    break;
+                case "size":
+                    map.put(name, attrs.size());
+                    break;
+                case "fileKey":
+                    map.put(name, attrs.fileKey());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown attribute: " + name);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * An iterator over directory children that applies a filter and produces
+     * absolute {@link ReadOnlyZipPath} instances.
+     */
+    private static class FilteredChildIterator implements Iterator<Path> {
+
+        private final Path parent;
+        private final List<String> children;
+        private final DirectoryStream.Filter<? super Path> filter;
+        private final ReadOnlyZipFileSystem fs;
+        private int index;
+        private Path next;
+
+        FilteredChildIterator(Path parent, List<String> children,
+                DirectoryStream.Filter<? super Path> filter,
+                ReadOnlyZipFileSystem fs) {
+            this.parent = parent;
+            this.children = children;
+            this.filter = filter;
+            this.fs = fs;
+            advance();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public Path next() {
+            if (next == null) {
+                throw new NoSuchElementException();
+            }
+            Path result = next;
+            advance();
+            return result;
+        }
+
+        private void advance() {
+            next = null;
+            while (index < children.size()) {
+                String child = children.get(index++);
+                Path p = parent.resolve(child);
+                try {
+                    if (filter == null || filter.accept(p)) {
+                        next = p;
+                        return;
+                    }
+                } catch (IOException e) {
+                    throw new java.io.UncheckedIOException(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Read-only {@link BasicFileAttributeView} implementation.
+     */
+    private static class ReadOnlyBasicFileAttributeView implements BasicFileAttributeView {
+
+        private final Path path;
+        private final ReadOnlyZipFileSystemProvider provider;
+
+        ReadOnlyBasicFileAttributeView(Path path, ReadOnlyZipFileSystemProvider provider) {
+            this.path = path;
+            this.provider = provider;
+        }
+
+        @Override
+        public String name() {
+            return "basic";
+        }
+
+        @Override
+        public BasicFileAttributes readAttributes() throws IOException {
+            return provider.readAttributes(path, BasicFileAttributes.class);
+        }
+
+        /** @throws ReadOnlyFileSystemException always */
+        @Override
+        public void setTimes(FileTime lastModifiedTime, FileTime lastAccessTime,
+                FileTime createTime) throws IOException {
+            throw new ReadOnlyFileSystemException();
+        }
+    }
+
+    /**
+     * A read-only {@link SeekableByteChannel} backed by a byte array.
+     * <p>
+     * This class is not thread-safe. Each call to
+     * {@link #newByteChannel(Path, Set, FileAttribute[])} creates a fresh
+     * instance, so concurrent access is not an issue in normal usage.
+     */
+    static class ByteArrayChannel implements SeekableByteChannel {
+
+        private final byte[] data;
+        private int position;
+        private boolean open = true;
+
+        ByteArrayChannel(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            ensureOpen();
+            if (position >= data.length) {
+                return -1;
+            }
+            int remaining = data.length - position;
+            int toRead = Math.min(dst.remaining(), remaining);
+            dst.put(data, position, toRead);
+            position += toRead;
+            return toRead;
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            throw new NonWritableChannelException();
+        }
+
+        @Override
+        public long position() throws IOException {
+            ensureOpen();
+            return position;
+        }
+
+        @Override
+        public SeekableByteChannel position(long newPosition) throws IOException {
+            ensureOpen();
+            if (newPosition < 0 || newPosition > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("Invalid position: " + newPosition);
+            }
+            this.position = (int) newPosition;
+            return this;
+        }
+
+        @Override
+        public long size() throws IOException {
+            ensureOpen();
+            return data.length;
+        }
+
+        @Override
+        public SeekableByteChannel truncate(long size) throws IOException {
+            throw new NonWritableChannelException();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void close() throws IOException {
+            open = false;
+        }
+
+        private void ensureOpen() throws ClosedChannelException {
+            if (!open) {
+                throw new ClosedChannelException();
+            }
+        }
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipPath.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ReadOnlyZipPath.java
@@ -1,0 +1,543 @@
+package io.quarkus.fs.util.rozip;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.ProviderMismatchException;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * {@link Path} implementation for entries within a {@link ReadOnlyZipFileSystem}.
+ * <p>
+ * All operations are pure string manipulation using {@code "/"} as the
+ * separator. Absolute paths start with {@code "/"}, relative paths do not.
+ * The root directory is represented by {@code "/"}.
+ * <p>
+ * Instances are created by {@link ReadOnlyZipFileSystem#getPath(String, String...)}.
+ */
+class ReadOnlyZipPath implements Path {
+
+    private final ReadOnlyZipFileSystem fileSystem;
+    private final String path;
+    private volatile int[] offsets;
+
+    /**
+     * Creates a new path in the given filesystem.
+     *
+     * @param fileSystem the owning filesystem
+     * @param path the normalized path string
+     */
+    ReadOnlyZipPath(ReadOnlyZipFileSystem fileSystem, String path) {
+        this.fileSystem = fileSystem;
+        this.path = path;
+    }
+
+    /**
+     * @return the raw path string
+     */
+    String getPathString() {
+        return path;
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+
+    @Override
+    public boolean isAbsolute() {
+        return path.startsWith("/");
+    }
+
+    @Override
+    public Path getRoot() {
+        return isAbsolute() ? fileSystem.getRootPath() : null;
+    }
+
+    @Override
+    public Path getFileName() {
+        if (path.isEmpty()) {
+            return this;
+        }
+
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash == -1) {
+            return this;
+        }
+        final int length = path.length();
+        if (lastSlash == 0) {
+            return length == 1 ? null : new ReadOnlyZipPath(fileSystem, path.substring(1));
+        }
+        if (lastSlash == length - 1) {
+            lastSlash = path.lastIndexOf('/', lastSlash - 1);
+            return lastSlash == -1 ? new ReadOnlyZipPath(fileSystem, path.substring(0, length - 1))
+                    : new ReadOnlyZipPath(fileSystem, path.substring(lastSlash + 1, length - 1));
+        }
+        return new ReadOnlyZipPath(fileSystem, path.substring(lastSlash + 1));
+    }
+
+    @Override
+    public Path getParent() {
+        if (path.isEmpty() || path.equals("/")) {
+            return null;
+        }
+        int end = path.length();
+        if (path.charAt(end - 1) == '/') {
+            end--;
+        }
+        int lastSlash = path.lastIndexOf('/', end - 1);
+        if (lastSlash < 0) {
+            return null;
+        }
+        if (lastSlash == 0) {
+            return fileSystem.getRootPath();
+        }
+        return new ReadOnlyZipPath(fileSystem, path.substring(0, lastSlash));
+    }
+
+    @Override
+    public int getNameCount() {
+        return getOffsets().length;
+    }
+
+    @Override
+    public Path getName(int index) {
+        int[] offs = getOffsets();
+        if (index < 0 || index >= offs.length) {
+            throw new IllegalArgumentException("index: " + index);
+        }
+        return new ReadOnlyZipPath(fileSystem, componentAt(offs, index));
+    }
+
+    @Override
+    public Path subpath(int beginIndex, int endIndex) {
+        int[] offs = getOffsets();
+        if (beginIndex < 0 || beginIndex >= offs.length
+                || endIndex <= beginIndex || endIndex > offs.length) {
+            throw new IllegalArgumentException("subpath(" + beginIndex + ", " + endIndex + ")");
+        }
+        if (endIndex - beginIndex == 1) {
+            return new ReadOnlyZipPath(fileSystem, componentAt(offs, beginIndex));
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = beginIndex; i < endIndex; i++) {
+            if (!sb.isEmpty()) {
+                sb.append('/');
+            }
+            sb.append(componentAt(offs, i));
+        }
+        return new ReadOnlyZipPath(fileSystem, sb.toString());
+    }
+
+    @Override
+    public boolean startsWith(Path other) {
+        ReadOnlyZipPath o = toReadOnlyZipPath(other);
+        if (o == null || this.isAbsolute() != o.isAbsolute()) {
+            return false;
+        }
+        int[] thisOffs = getOffsets();
+        int[] otherOffs = o.getOffsets();
+        if (otherOffs.length > thisOffs.length) {
+            return false;
+        }
+        // root starts with root
+        if (o.path.equals("/") && this.isAbsolute()) {
+            return true;
+        }
+        for (int i = 0; i < otherOffs.length; i++) {
+            if (!componentEquals(thisOffs, i, o, otherOffs, i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean startsWith(String other) {
+        return startsWith(fileSystem.getPath(other));
+    }
+
+    @Override
+    public boolean endsWith(Path other) {
+        ReadOnlyZipPath o = toReadOnlyZipPath(other);
+        if (o == null) {
+            return false;
+        }
+        if (o.isAbsolute()) {
+            return this.isAbsolute() && this.path.equals(o.path);
+        }
+        int[] thisOffs = getOffsets();
+        int[] otherOffs = o.getOffsets();
+        if (otherOffs.length > thisOffs.length) {
+            return false;
+        }
+        int diff = thisOffs.length - otherOffs.length;
+        for (int i = otherOffs.length - 1; i >= 0; i--) {
+            if (!componentEquals(thisOffs, diff + i, o, otherOffs, i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean endsWith(String other) {
+        return endsWith(fileSystem.getPath(other));
+    }
+
+    @Override
+    public Path normalize() {
+        if (path.indexOf('.') < 0) {
+            return this;
+        }
+        int[] offs = getOffsets();
+        if (offs.length == 0) {
+            return this;
+        }
+        String[] components = new String[offs.length];
+        for (int i = 0; i < offs.length; i++) {
+            components[i] = componentAt(offs, i);
+        }
+        return buildNormalized(components, isAbsolute());
+    }
+
+    /**
+     * Processes {@code "."} and {@code ".."} components and builds a new path.
+     */
+    private Path buildNormalized(String[] components, boolean absolute) {
+        String[] result = new String[components.length];
+        int len = 0;
+        for (String c : components) {
+            if (c.equals(".")) {
+                continue;
+            }
+            if (c.equals("..")) {
+                if (len > 0 && !result[len - 1].equals("..")) {
+                    len--;
+                } else if (!absolute) {
+                    result[len++] = c;
+                }
+                continue;
+            }
+            result[len++] = c;
+        }
+        if (len == 0) {
+            return absolute ? fileSystem.getRootPath() : new ReadOnlyZipPath(fileSystem, "");
+        }
+        StringBuilder sb = new StringBuilder();
+        if (absolute) {
+            sb.append('/');
+        }
+        for (int i = 0; i < len; i++) {
+            if (i > 0) {
+                sb.append('/');
+            }
+            sb.append(result[i]);
+        }
+        return new ReadOnlyZipPath(fileSystem, sb.toString());
+    }
+
+    @Override
+    public Path resolve(Path other) {
+        ReadOnlyZipPath o = requireSameFs(other);
+        if (o.isAbsolute() || this.path.isEmpty()) {
+            return o;
+        }
+        if (o.path.isEmpty()) {
+            return this;
+        }
+        if (path.endsWith("/")) {
+            return new ReadOnlyZipPath(fileSystem, path + o.path);
+        }
+        return new ReadOnlyZipPath(fileSystem, path + "/" + o.path);
+    }
+
+    @Override
+    public Path resolve(String other) {
+        return resolve(fileSystem.getPath(other));
+    }
+
+    @Override
+    public Path resolveSibling(Path other) {
+        Objects.requireNonNull(other);
+        Path parent = getParent();
+        return parent == null ? other : parent.resolve(other);
+    }
+
+    @Override
+    public Path resolveSibling(String other) {
+        return resolveSibling(fileSystem.getPath(other));
+    }
+
+    @Override
+    public Path relativize(Path other) {
+        ReadOnlyZipPath o = requireSameFs(other);
+        if (this.isAbsolute() != o.isAbsolute()) {
+            throw new IllegalArgumentException("Cannot relativize paths with different roots");
+        }
+        if (this.path.equals(o.path)) {
+            return new ReadOnlyZipPath(fileSystem, "");
+        }
+        int[] thisOffs = getOffsets();
+        int[] otherOffs = o.getOffsets();
+        int common = countCommonComponents(thisOffs, otherOffs, o);
+        return buildRelativized(thisOffs, otherOffs, common, o);
+    }
+
+    /**
+     * Counts the number of leading path components that {@code this} and
+     * {@code other} have in common.
+     */
+    private int countCommonComponents(int[] thisOffs, int[] otherOffs, ReadOnlyZipPath other) {
+        int minLen = Math.min(thisOffs.length, otherOffs.length);
+        int common = 0;
+        for (int i = 0; i < minLen; i++) {
+            if (componentAt(thisOffs, i).equals(other.componentAt(otherOffs, i))) {
+                common++;
+            } else {
+                break;
+            }
+        }
+        return common;
+    }
+
+    /**
+     * Builds the relativized path: {@code n} {@code ".."} components followed
+     * by the remaining components of {@code other}.
+     */
+    private Path buildRelativized(int[] thisOffs, int[] otherOffs, int common, ReadOnlyZipPath other) {
+        int dotDots = thisOffs.length - common;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < dotDots; i++) {
+            if (!sb.isEmpty()) {
+                sb.append('/');
+            }
+            sb.append("..");
+        }
+        for (int i = common; i < otherOffs.length; i++) {
+            if (!sb.isEmpty()) {
+                sb.append('/');
+            }
+            sb.append(other.componentAt(otherOffs, i));
+        }
+        return new ReadOnlyZipPath(fileSystem, sb.toString());
+    }
+
+    @Override
+    public URI toUri() {
+        return fileSystem.entryUri(toAbsolutePath().toString());
+    }
+
+    @Override
+    public Path toAbsolutePath() {
+        if (isAbsolute()) {
+            return this;
+        }
+        return new ReadOnlyZipPath(fileSystem, "/" + path);
+    }
+
+    @Override
+    public Path toRealPath(LinkOption... options) throws IOException {
+        return toAbsolutePath().normalize();
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; ZIP paths cannot be
+     *         converted to {@link File}
+     */
+    @Override
+    public File toFile() {
+        throw new UnsupportedOperationException("ZIP path cannot be converted to File");
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; ZIP filesystems do not
+     *         support watch services
+     */
+    @Override
+    public WatchKey register(WatchService watcher, WatchEvent.Kind<?>[] events,
+            WatchEvent.Modifier... modifiers) throws IOException {
+        throw new UnsupportedOperationException("Watch service not supported");
+    }
+
+    /**
+     * @throws UnsupportedOperationException always; ZIP filesystems do not
+     *         support watch services
+     */
+    @Override
+    public WatchKey register(WatchService watcher, WatchEvent.Kind<?>... events) throws IOException {
+        throw new UnsupportedOperationException("Watch service not supported");
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        return new Iterator<>() {
+            private int index = 0;
+            private final int count = getNameCount();
+
+            @Override
+            public boolean hasNext() {
+                return index < count;
+            }
+
+            @Override
+            public Path next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return getName(index++);
+            }
+        };
+    }
+
+    @Override
+    public int compareTo(Path other) {
+        ReadOnlyZipPath o = requireSameFs(other);
+        return this.path.compareTo(o.path);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof ReadOnlyZipPath other) {
+            return fileSystem == other.fileSystem && path.equals(other.path);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return path;
+    }
+
+    /**
+     * Lazily computes the offsets of each name component in the path string.
+     * For path {@code "/a/b/c"}, the offsets point to {@code "a"}, {@code "b"},
+     * {@code "c"}.
+     */
+    private int[] getOffsets() {
+        int[] result = offsets;
+        if (result == null) {
+            result = computeOffsets();
+            offsets = result;
+        }
+        return result;
+    }
+
+    /**
+     * Computes name component offsets. Each offset is the start index of a
+     * component in the path string, after skipping the leading {@code "/"}.
+     */
+    private int[] computeOffsets() {
+        int len = path.length();
+        if (len > 1 && path.charAt(len - 1) == '/') {
+            len--;
+        }
+        if (len == 0 || (len == 1 && path.charAt(0) == '/')) {
+            return new int[0];
+        }
+        int start = path.charAt(0) == '/' ? 1 : 0;
+        int count = 1;
+        for (int i = start; i < len; i++) {
+            if (path.charAt(i) == '/') {
+                count++;
+            }
+        }
+        int[] offs = new int[count];
+        int idx = 0;
+        offs[idx++] = start;
+        for (int i = start; i < len; i++) {
+            if (path.charAt(i) == '/') {
+                offs[idx++] = i + 1;
+            }
+        }
+        return offs;
+    }
+
+    private int pathLengthWithoutTrailingSlash() {
+        int len = path.length();
+        return (len > 1 && path.charAt(len - 1) == '/') ? len - 1 : len;
+    }
+
+    /**
+     * Returns the name component at the given index using precomputed offsets.
+     */
+    private String componentAt(int[] offs, int index) {
+        return path.substring(componentStart(offs, index), componentEnd(offs, index));
+    }
+
+    /**
+     * @return the start index (inclusive) of the component at {@code index}
+     */
+    private int componentStart(int[] offs, int index) {
+        return offs[index];
+    }
+
+    /**
+     * @return the end index (exclusive) of the component at {@code index}
+     */
+    private int componentEnd(int[] offs, int index) {
+        return (index + 1 < offs.length) ? offs[index + 1] - 1 : pathLengthWithoutTrailingSlash();
+    }
+
+    /**
+     * Compares a component of this path with a component of another path
+     * without allocating substrings.
+     */
+    private boolean componentEquals(int[] thisOffs, int thisIndex,
+            ReadOnlyZipPath other, int[] otherOffs, int otherIndex) {
+        int thisStart = componentStart(thisOffs, thisIndex);
+        int thisEnd = componentEnd(thisOffs, thisIndex);
+        int otherStart = other.componentStart(otherOffs, otherIndex);
+        int otherEnd = other.componentEnd(otherOffs, otherIndex);
+        int len = thisEnd - thisStart;
+        if (len != otherEnd - otherStart) {
+            return false;
+        }
+        return path.regionMatches(thisStart, other.path, otherStart, len);
+    }
+
+    /**
+     * Casts the given path to {@link ReadOnlyZipPath} and verifies it belongs
+     * to the same filesystem.
+     *
+     * @throws ProviderMismatchException if the path is from a different provider
+     */
+    private ReadOnlyZipPath requireSameFs(Path other) {
+        Objects.requireNonNull(other);
+        if (other instanceof ReadOnlyZipPath o) {
+            return o;
+        }
+        throw new ProviderMismatchException("Expected ReadOnlyZipPath but got " + other.getClass().getName());
+    }
+
+    /**
+     * Attempts to cast the given path to {@link ReadOnlyZipPath} from the same
+     * filesystem.
+     *
+     * @return the cast path, or {@code null} if incompatible
+     */
+    private ReadOnlyZipPath toReadOnlyZipPath(Path other) {
+        if (other instanceof ReadOnlyZipPath o) {
+            if (o.fileSystem == this.fileSystem) {
+                return o;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ZipCentralDirectory.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ZipCentralDirectory.java
@@ -1,0 +1,320 @@
+package io.quarkus.fs.util.rozip;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * Parses the ZIP central directory from a {@link RandomAccessFile} and produces
+ * an entry index and directory tree.
+ * <p>
+ * The parser handles both standard ZIP and ZIP64 formats. All I/O is performed
+ * through the provided {@link RandomAccessFile}, which is <em>not</em> an
+ * {@link java.nio.channels.InterruptibleChannel} and therefore immune to
+ * thread-interrupt-induced channel closures.
+ * <p>
+ * After construction, the {@link RandomAccessFile} is not accessed by this
+ * class; callers retain ownership of the file handle.
+ * <p>
+ * Entry names are decoded as UTF-8. Archives that use the legacy CP437
+ * encoding (general-purpose bit 11 unset) may produce incorrect names.
+ */
+final class ZipCentralDirectory {
+
+    // ZIP signature constants
+    private static final int EOCD_SIG = 0x06054b50;
+    private static final int ZIP64_EOCD_SIG = 0x06064b50;
+    private static final int ZIP64_EOCD_LOCATOR_SIG = 0x07064b50;
+    static final int CENTRAL_DIR_SIG = 0x02014b50;
+
+    // EOCD sizes
+    private static final int EOCD_MIN_SIZE = 22;
+    private static final int EOCD_MAX_COMMENT = 65535;
+
+    // Extra field tags
+    private static final int ZIP64_EXTRA_TAG = 0x0001;
+    private static final int NTFS_EXTRA_TAG = 0x000a;
+    private static final int UNIX_EXTRA_TAG = 0x5455;
+
+    // Milliseconds between the Windows FILETIME epoch (1601-01-01) and the Unix epoch (1970-01-01)
+    private static final long WINDOWS_EPOCH_DIFF_MILLIS = 11_644_473_600_000L;
+
+    private static final long MAX_CENTRAL_DIR_SIZE = 256 * 1024 * 1024L; // 256 MB
+
+    private final CompactEntryTable entryTable;
+
+    private ZipCentralDirectory(CompactEntryTable entryTable) {
+        this.entryTable = entryTable;
+    }
+
+    /**
+     * Parses the central directory of the ZIP file accessible through the given
+     * {@link RandomAccessFile}.
+     *
+     * @param raf an open {@link RandomAccessFile} positioned anywhere; the method
+     *        seeks as needed
+     * @return a parsed central directory containing entry metadata and directory tree
+     * @throws IOException if the file cannot be read or is not a valid ZIP archive
+     */
+    static ZipCentralDirectory parse(RandomAccessFile raf) throws IOException {
+        long fileLength = raf.length();
+        if (fileLength < EOCD_MIN_SIZE) {
+            throw new IOException("File is too small to be a valid ZIP archive");
+        }
+
+        long[] eocdInfo = findEocd(raf, fileLength);
+        long cdOffset = eocdInfo[0];
+        long cdSize = eocdInfo[1];
+        long totalEntries = eocdInfo[2];
+
+        if (cdSize > MAX_CENTRAL_DIR_SIZE) {
+            throw new IOException("Central directory too large (" + cdSize
+                    + " bytes, limit " + MAX_CENTRAL_DIR_SIZE + ")");
+        }
+        byte[] cdBytes = new byte[(int) cdSize];
+        raf.seek(cdOffset);
+        raf.readFully(cdBytes);
+
+        CompactEntryTable table = CompactEntryTable.buildFromCentralDirectory(
+                cdBytes, (int) cdSize, totalEntries, cdOffset);
+        return new ZipCentralDirectory(table);
+    }
+
+    CompactEntryTable entryTable() {
+        return entryTable;
+    }
+
+    /**
+     * Locates the End of Central Directory record and extracts the central
+     * directory offset, size, and total entry count. Handles ZIP64 if needed.
+     *
+     * @return array of {@code [cdOffset, cdSize, totalEntries]}
+     */
+    private static long[] findEocd(RandomAccessFile raf, long fileLength) throws IOException {
+        int searchLen = (int) Math.min(fileLength, EOCD_MIN_SIZE + EOCD_MAX_COMMENT);
+        long searchStart = fileLength - searchLen;
+        byte[] buf = new byte[searchLen];
+
+        raf.seek(searchStart);
+        raf.readFully(buf);
+
+        int eocdPos = findEocdSignature(buf);
+        if (eocdPos < 0) {
+            throw new IOException("End of Central Directory signature not found; not a valid ZIP file");
+        }
+
+        long totalEntries = LittleEndian.readUint16(buf, eocdPos + 10);
+        long cdSize = LittleEndian.readUint32(buf, eocdPos + 12);
+        long cdOffset = LittleEndian.readUint32(buf, eocdPos + 16);
+
+        if (needsZip64(totalEntries, cdSize, cdOffset)) {
+            return readZip64Eocd(raf, searchStart + eocdPos);
+        }
+
+        return new long[] { cdOffset, cdSize, totalEntries };
+    }
+
+    /**
+     * Scans the buffer backwards for the EOCD signature {@code PK\x05\x06}.
+     *
+     * @return offset within the buffer, or {@code -1} if not found
+     */
+    private static int findEocdSignature(byte[] buf) {
+        for (int i = buf.length - EOCD_MIN_SIZE; i >= 0; i--) {
+            if (LittleEndian.readInt32(buf, i) == EOCD_SIG) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * @return {@code true} if any EOCD field indicates ZIP64 is needed
+     */
+    private static boolean needsZip64(long totalEntries, long cdSize, long cdOffset) {
+        return totalEntries == 0xFFFFL || cdSize == 0xFFFFFFFFL || cdOffset == 0xFFFFFFFFL;
+    }
+
+    /**
+     * Reads the ZIP64 End of Central Directory record and returns the 64-bit
+     * central directory offset, size, and total entry count.
+     *
+     * @param raf the archive file
+     * @param eocdOffset absolute file offset of the standard EOCD record
+     * @return array of {@code [cdOffset, cdSize, totalEntries]}
+     */
+    private static long[] readZip64Eocd(RandomAccessFile raf, long eocdOffset) throws IOException {
+        long locatorOffset = eocdOffset - 20;
+        if (locatorOffset < 0) {
+            throw new IOException("ZIP64 EOCD locator not found");
+        }
+
+        byte[] locator = new byte[20];
+        raf.seek(locatorOffset);
+        raf.readFully(locator);
+
+        if (LittleEndian.readInt32(locator, 0) != ZIP64_EOCD_LOCATOR_SIG) {
+            throw new IOException("ZIP64 EOCD locator signature mismatch");
+        }
+
+        long zip64EocdOffset = LittleEndian.readUint64(locator, 8);
+
+        byte[] eocd64 = new byte[56];
+        raf.seek(zip64EocdOffset);
+        raf.readFully(eocd64);
+
+        if (LittleEndian.readInt32(eocd64, 0) != ZIP64_EOCD_SIG) {
+            throw new IOException("ZIP64 EOCD signature mismatch");
+        }
+
+        long totalEntries = LittleEndian.readUint64(eocd64, 32);
+        long cdSize = LittleEndian.readUint64(eocd64, 40);
+        long cdOffset = LittleEndian.readUint64(eocd64, 48);
+
+        return new long[] { cdOffset, cdSize, totalEntries };
+    }
+
+    /**
+     * @return {@code true} if any size or offset field contains the ZIP64
+     *         sentinel value {@code 0xFFFFFFFF}
+     */
+    static boolean hasZip64Overrides(long compressedSize, long uncompressedSize, long localHeaderOffset) {
+        return compressedSize == 0xFFFFFFFFL
+                || uncompressedSize == 0xFFFFFFFFL
+                || localHeaderOffset == 0xFFFFFFFFL;
+    }
+
+    /**
+     * Reads 64-bit values from the ZIP64 extended information extra field.
+     * <p>
+     * The ZIP64 extra field stores values in order: uncompressed size, compressed
+     * size, local header offset — but only for fields whose standard counterpart
+     * contains the sentinel value {@code 0xFFFFFFFF}.
+     *
+     * @return array of {@code [uncompressedSize, compressedSize, localHeaderOffset]}
+     *         with ZIP64 values replacing any sentinel values
+     */
+    static long[] readZip64Extra(byte[] extra, int offset, int extraLen,
+            long uncompressedSize, long compressedSize, long localHeaderOffset) {
+        int end = offset + extraLen;
+        int pos = offset;
+        while (pos + 4 <= end) {
+            int tag = LittleEndian.readUint16(extra, pos);
+            int dataSize = LittleEndian.readUint16(extra, pos + 2);
+            if (tag == ZIP64_EXTRA_TAG) {
+                int dataPos = pos + 4;
+                int zip64End = Math.min(pos + 4 + dataSize, end);
+                if (uncompressedSize == 0xFFFFFFFFL && dataPos + 8 <= zip64End) {
+                    uncompressedSize = LittleEndian.readUint64(extra, dataPos);
+                    dataPos += 8;
+                }
+                if (compressedSize == 0xFFFFFFFFL && dataPos + 8 <= zip64End) {
+                    compressedSize = LittleEndian.readUint64(extra, dataPos);
+                    dataPos += 8;
+                }
+                if (localHeaderOffset == 0xFFFFFFFFL && dataPos + 8 <= zip64End) {
+                    localHeaderOffset = LittleEndian.readUint64(extra, dataPos);
+                }
+                break;
+            }
+            pos += 4 + dataSize;
+        }
+        return new long[] { uncompressedSize, compressedSize, localHeaderOffset };
+    }
+
+    /**
+     * Scans the extra field for high-precision timestamps. Checks for NTFS
+     * (tag {@code 0x000a}) and Unix extended timestamp (tag {@code 0x5455})
+     * extra fields. Returns the best available last-modified time with
+     * priority: NTFS &gt; Unix extended &gt; DOS fallback.
+     *
+     * @param cd the central directory byte array
+     * @param extraOffset start of the extra field data
+     * @param extraLen length of the extra field
+     * @param dosFallback last-modified time from DOS fields (epoch millis)
+     * @return last-modified time in epoch milliseconds
+     */
+    static long readTimestampFromExtra(byte[] cd, int extraOffset, int extraLen, long dosFallback) {
+        int end = extraOffset + extraLen;
+        int pos = extraOffset;
+        long ntfsMillis = Long.MIN_VALUE;
+        long unixMillis = Long.MIN_VALUE;
+
+        while (pos + 4 <= end) {
+            int tag = LittleEndian.readUint16(cd, pos);
+            int dataSize = LittleEndian.readUint16(cd, pos + 2);
+            int dataStart = pos + 4;
+            int dataEnd = dataStart + dataSize;
+            if (dataEnd > end) {
+                break;
+            }
+
+            if (tag == NTFS_EXTRA_TAG) {
+                // 4 bytes reserved, then attribute blocks
+                int attrPos = dataStart + 4;
+                while (attrPos + 4 <= dataEnd) {
+                    int attrTag = LittleEndian.readUint16(cd, attrPos);
+                    int attrSize = LittleEndian.readUint16(cd, attrPos + 2);
+                    if (attrTag == 0x0001 && attrSize >= 8 && attrPos + 4 + 8 <= dataEnd) {
+                        long winTime = LittleEndian.readUint64(cd, attrPos + 4);
+                        if (winTime > 0) {
+                            ntfsMillis = winTime / 10_000 - WINDOWS_EPOCH_DIFF_MILLIS;
+                        }
+                        break;
+                    }
+                    attrPos += 4 + attrSize;
+                }
+            } else if (tag == UNIX_EXTRA_TAG && dataSize >= 5) {
+                int flags = cd[dataStart] & 0xFF;
+                if ((flags & 0x01) != 0) {
+                    // Signed 32-bit Unix time, consistent with the JDK
+                    long unixSeconds = LittleEndian.readInt32(cd, dataStart + 1);
+                    unixMillis = unixSeconds * 1000L;
+                }
+            }
+
+            pos = dataEnd;
+        }
+
+        if (ntfsMillis != Long.MIN_VALUE) {
+            return ntfsMillis;
+        }
+        if (unixMillis != Long.MIN_VALUE) {
+            return unixMillis;
+        }
+        return dosFallback;
+    }
+
+    /**
+     * Converts DOS date and time fields to epoch milliseconds.
+     *
+     * @param dosDate DOS-format date (bits: 15-9 = year-1980, 8-5 = month, 4-0 = day)
+     * @param dosTime DOS-format time (bits: 15-11 = hour, 10-5 = minute, 4-0 = second/2)
+     * @return epoch milliseconds in the system default time zone
+     */
+    static long dosToEpochMillis(int dosDate, int dosTime) {
+        int year = ((dosDate >> 9) & 0x7F) + 1980;
+        int month = (dosDate >> 5) & 0x0F;
+        int day = dosDate & 0x1F;
+        int hour = (dosTime >> 11) & 0x1F;
+        int minute = (dosTime >> 5) & 0x3F;
+        int second = (dosTime & 0x1F) * 2;
+
+        if (month < 1)
+            month = 1;
+        if (day < 1)
+            day = 1;
+
+        try {
+            // System default timezone, consistent with JDK's ZipFileSystem
+            return LocalDateTime.of(year, month, day, hour, minute, second)
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+
+}

--- a/src/main/java/io/quarkus/fs/util/rozip/ZipEntryInfo.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/ZipEntryInfo.java
@@ -1,0 +1,29 @@
+package io.quarkus.fs.util.rozip;
+
+/**
+ * Immutable metadata for a single ZIP entry, parsed from the central directory.
+ * <p>
+ * Instances are created during {@link ZipCentralDirectory} parsing and remain
+ * constant for the lifetime of the {@link ReadOnlyZipFileSystem}.
+ *
+ * @param name the entry path within the archive (e.g. {@code "com/example/Foo.class"})
+ * @param compressedSize compressed size in bytes
+ * @param uncompressedSize uncompressed size in bytes
+ * @param compressionMethod compression method ({@code 0} = STORED, {@code 8} = DEFLATED)
+ * @param crc32 CRC-32 checksum of the uncompressed data
+ * @param localHeaderOffset byte offset of this entry's local file header in the ZIP file
+ * @param directory whether this entry represents a directory
+ * @param lastModifiedTime last-modified timestamp in epoch milliseconds
+ */
+record ZipEntryInfo(
+        String name,
+        long compressedSize,
+        long uncompressedSize,
+        int compressionMethod,
+        long crc32,
+        long localHeaderOffset,
+        boolean directory,
+        long lastModifiedTime) {
+
+    static final String ROOT_ENTRY_NAME = "";
+}

--- a/src/test/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystemTest.java
+++ b/src/test/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystemTest.java
@@ -1,0 +1,2076 @@
+package io.quarkus.fs.util.rozip;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.fs.util.ZipUtils;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.ClosedFileSystemException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.ReadOnlyFileSystemException;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the read-only, non-interruptible ZIP filesystem.
+ */
+class ReadOnlyZipFileSystemTest {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void resetCache() {
+        ReadOnlyZipFileSystem.CACHE_ENABLED = false;
+    }
+
+    // -- Entry reading --
+
+    @Test
+    void readTextEntry() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("hello.txt", "hello world"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            String content = Files.readString(fs.getPath("/hello.txt"));
+            assertEquals("hello world", content);
+        }
+    }
+
+    @Test
+    void readAllBytes() throws IOException {
+        byte[] data = { 1, 2, 3, 4, 5 };
+        Path zip = createZip("test.zip",
+                entry("binary.dat", data));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            byte[] read = Files.readAllBytes(fs.getPath("/binary.dat"));
+            assertArrayEquals(data, read);
+        }
+    }
+
+    @Test
+    void readViaInputStream() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("data.txt", "test content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                InputStream is = Files.newInputStream(fs.getPath("/data.txt"))) {
+            String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertEquals("test content", content);
+        }
+    }
+
+    @Test
+    void readStoredEntry() throws IOException {
+        Path zip = createZipWithMethod("stored.zip", ZipEntry.STORED,
+                entry("file.txt", "stored content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            String content = Files.readString(fs.getPath("/file.txt"));
+            assertEquals("stored content", content);
+        }
+    }
+
+    @Test
+    void readNonExistentEntryThrows() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("exists.txt", "yes"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertThrows(NoSuchFileException.class,
+                    () -> Files.readAllBytes(fs.getPath("/missing.txt")));
+        }
+    }
+
+    // -- Directory traversal --
+
+    @Test
+    void walkDirectoryTree() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a/b/c.txt", "c"),
+                entry("a/d.txt", "d"),
+                entry("e.txt", "e"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                Stream<Path> stream = Files.walk(fs.getPath("/"))) {
+            List<String> paths = stream.map(Path::toString).sorted().collect(Collectors.toList());
+            assertTrue(paths.contains("/"), "Should contain root");
+            assertTrue(paths.contains("/a"), "Should contain /a");
+            assertTrue(paths.contains("/a/b"), "Should contain /a/b");
+            assertTrue(paths.contains("/a/b/c.txt"), "Should contain /a/b/c.txt");
+            assertTrue(paths.contains("/a/d.txt"), "Should contain /a/d.txt");
+            assertTrue(paths.contains("/e.txt"), "Should contain /e.txt");
+        }
+    }
+
+    @Test
+    void listDirectory() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("dir/alpha.txt", "a"),
+                entry("dir/beta.txt", "b"),
+                entry("other.txt", "c"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                DirectoryStream<Path> stream = Files.newDirectoryStream(fs.getPath("/dir"))) {
+            List<String> names = new ArrayList<>();
+            stream.forEach(p -> names.add(p.getFileName().toString()));
+            Collections.sort(names);
+            assertEquals(List.of("alpha.txt", "beta.txt"), names);
+        }
+    }
+
+    @Test
+    void listRoot() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a.txt", "a"),
+                entry("b/c.txt", "c"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                Stream<Path> stream = Files.list(fs.getPath("/"))) {
+            List<String> names = stream
+                    .map(p -> p.getFileName().toString())
+                    .sorted()
+                    .collect(Collectors.toList());
+            assertEquals(List.of("a.txt", "b"), names);
+        }
+    }
+
+    // -- Existence and type checks --
+
+    @Test
+    void existsAndTypeChecks() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("file.txt", "content"),
+                entry("dir/inner.txt", "inner"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertTrue(Files.exists(fs.getPath("/")));
+            assertTrue(Files.exists(fs.getPath("/file.txt")));
+            assertTrue(Files.exists(fs.getPath("/dir")));
+            assertFalse(Files.exists(fs.getPath("/nonexistent")));
+
+            assertTrue(Files.isDirectory(fs.getPath("/")));
+            assertTrue(Files.isDirectory(fs.getPath("/dir")));
+            assertFalse(Files.isDirectory(fs.getPath("/file.txt")));
+
+            assertTrue(Files.isRegularFile(fs.getPath("/file.txt")));
+            assertFalse(Files.isRegularFile(fs.getPath("/dir")));
+
+            // trailing-slash paths must resolve the same as without
+            assertTrue(Files.exists(fs.getPath("/dir/")));
+            assertTrue(Files.isDirectory(fs.getPath("/dir/")));
+            assertEquals("inner", Files.readString(fs.getPath("/dir/inner.txt")));
+        }
+    }
+
+    // -- Attributes --
+
+    @Test
+    void readBasicAttributes() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("file.txt", "content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            BasicFileAttributes attrs = Files.readAttributes(
+                    fs.getPath("/file.txt"), BasicFileAttributes.class);
+            assertTrue(attrs.isRegularFile());
+            assertFalse(attrs.isDirectory());
+            assertEquals(7, attrs.size()); // "content" = 7 bytes
+            assertNotNull(attrs.lastModifiedTime());
+
+            BasicFileAttributes rootAttrs = Files.readAttributes(
+                    fs.getPath("/"), BasicFileAttributes.class);
+            assertTrue(rootAttrs.isDirectory());
+        }
+    }
+
+    @Test
+    void implicitDirectoryAttributesHaveEpochZeroTimestamp() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a/b/file.txt", "content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            // "a" and "a/b" are implicit directories (no explicit central directory entry)
+            BasicFileAttributes implicitAttrs = Files.readAttributes(
+                    fs.getPath("/a"), BasicFileAttributes.class);
+            assertTrue(implicitAttrs.isDirectory());
+            assertEquals(FileTime.fromMillis(0L), implicitAttrs.lastModifiedTime(),
+                    "Implicit directories should report epoch 0, consistent with the JDK's ZipFileSystem");
+            assertEquals(0L, implicitAttrs.size());
+
+            // The file itself should have a real timestamp
+            BasicFileAttributes fileAttrs = Files.readAttributes(
+                    fs.getPath("/a/b/file.txt"), BasicFileAttributes.class);
+            assertTrue(fileAttrs.lastModifiedTime().toMillis() > 0,
+                    "File entries should have a non-zero timestamp");
+        }
+    }
+
+    @Test
+    void newInputStreamOnImplicitDirectoryThrowsFileSystemException() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a/b/file.txt", "content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path implicitDir = fs.getPath("/a");
+            assertTrue(Files.exists(implicitDir));
+            assertTrue(Files.isDirectory(implicitDir));
+            FileSystemException ex = assertThrows(FileSystemException.class,
+                    () -> Files.newInputStream(implicitDir));
+            assertTrue(ex.getReason().contains("directory"), ex.getReason());
+        }
+    }
+
+    // -- Path operations --
+
+    @Test
+    void getPathJoinsComponents() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("a", "b", "c.txt");
+            assertEquals("a/b/c.txt", p.toString());
+        }
+    }
+
+    @Test
+    void resolveAndRelativize() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path a = fs.getPath("/a");
+            Path ab = a.resolve("b");
+            assertEquals("/a/b", ab.toString());
+
+            Path rel = fs.getPath("/a").relativize(fs.getPath("/a/b/c"));
+            assertEquals("b/c", rel.toString());
+        }
+    }
+
+    @Test
+    void getFileNameAndParent() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("/a/b/c.txt");
+            assertEquals("c.txt", p.getFileName().toString());
+            assertEquals("/a/b", p.getParent().toString());
+            assertEquals("/", p.getRoot().toString());
+
+            assertNull(fs.getPath("/").getFileName());
+            assertNull(fs.getPath("/").getParent());
+
+            Path dirWithSlash = fs.getPath("/dir/");
+            assertEquals("/", dirWithSlash.getParent().toString());
+            assertEquals("dir", dirWithSlash.getFileName().toString());
+        }
+    }
+
+    @Test
+    void nameCountAndSubpath() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("/a/b/c");
+            assertEquals(3, p.getNameCount());
+            assertEquals("a", p.getName(0).toString());
+            assertEquals("b", p.getName(1).toString());
+            assertEquals("c", p.getName(2).toString());
+            assertEquals("b/c", p.subpath(1, 3).toString());
+
+            assertEquals(0, fs.getPath("/").getNameCount());
+        }
+    }
+
+    @Test
+    void normalize() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("/a/c", fs.getPath("/a/b/../c").normalize().toString());
+            assertEquals("/a", fs.getPath("/a/./b/..").normalize().toString());
+            assertEquals("/", fs.getPath("/a/..").normalize().toString());
+        }
+    }
+
+    @Test
+    void toAbsolutePath() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path relative = fs.getPath("a/b");
+            assertFalse(relative.isAbsolute());
+            Path absolute = relative.toAbsolutePath();
+            assertTrue(absolute.isAbsolute());
+            assertEquals("/a/b", absolute.toString());
+        }
+    }
+
+    @Test
+    void startsWithAndEndsWith() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("/a/b/c");
+            assertTrue(p.startsWith("/a"));
+            assertTrue(p.startsWith("/a/b"));
+            assertFalse(p.startsWith("/b"));
+            assertTrue(p.endsWith("c"));
+            assertTrue(p.endsWith("b/c"));
+            assertFalse(p.endsWith("a"));
+        }
+    }
+
+    @Test
+    void pathEquality() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p1 = fs.getPath("/a/b");
+            Path p2 = fs.getPath("/a/b");
+            assertEquals(p1, p2);
+            assertEquals(p1.hashCode(), p2.hashCode());
+            assertEquals(0, p1.compareTo(p2));
+        }
+    }
+
+    @Test
+    void pathIterator() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            List<String> names = new ArrayList<>();
+            for (Path component : fs.getPath("/a/b/c")) {
+                names.add(component.toString());
+            }
+            assertEquals(List.of("a", "b", "c"), names);
+        }
+    }
+
+    // -- Read-only enforcement --
+
+    @Test
+    void isReadOnly() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertTrue(fs.isReadOnly());
+        }
+    }
+
+    @Test
+    void writeOperationsThrow() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertThrows(ReadOnlyFileSystemException.class,
+                    () -> Files.createDirectory(fs.getPath("/newdir")));
+            assertThrows(ReadOnlyFileSystemException.class,
+                    () -> Files.delete(fs.getPath("/x.txt")));
+            assertThrows(ReadOnlyFileSystemException.class,
+                    () -> Files.write(fs.getPath("/out.txt"), new byte[] { 1 }));
+        }
+    }
+
+    // -- Concurrent access --
+
+    @Test
+    void concurrentReads() throws Exception {
+        Path zip = createZip("test.zip",
+                entry("a.txt", "alpha"),
+                entry("b.txt", "bravo"),
+                entry("c.txt", "charlie"));
+
+        int threadCount = 32;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        AtomicInteger errors = new AtomicInteger();
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                final int idx = i;
+                futures.add(executor.submit(() -> {
+                    try {
+                        barrier.await();
+                        String[] files = { "a.txt", "b.txt", "c.txt" };
+                        String[] expected = { "alpha", "bravo", "charlie" };
+                        for (int j = 0; j < 100; j++) {
+                            int pick = (idx + j) % 3;
+                            String content = Files.readString(fs.getPath("/" + files[pick]));
+                            if (!expected[pick].equals(content)) {
+                                errors.incrementAndGet();
+                            }
+                        }
+                    } catch (Exception e) {
+                        errors.incrementAndGet();
+                    }
+                }));
+            }
+            for (Future<?> f : futures) {
+                f.get();
+            }
+        } finally {
+            executor.shutdown();
+        }
+
+        assertEquals(0, errors.get(), "No errors expected in concurrent reads");
+    }
+
+    // -- Interrupt resilience --
+
+    @Test
+    void interruptDoesNotBreakFileSystem() throws Exception {
+        Path zip = createZip("test.zip",
+                entry("data.txt", "important data"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            // Read normally first
+            assertEquals("important data", Files.readString(fs.getPath("/data.txt")));
+
+            // Set interrupt flag and read again
+            Thread.currentThread().interrupt();
+            try {
+                assertEquals("important data", Files.readString(fs.getPath("/data.txt")));
+            } finally {
+                // Verify interrupt flag is preserved
+                assertTrue(Thread.interrupted(), "Interrupt flag should be preserved");
+            }
+
+            // Read again after clearing interrupt — FS should still work
+            assertEquals("important data", Files.readString(fs.getPath("/data.txt")));
+        }
+    }
+
+    @Test
+    void interruptedThreadDoesNotAffectOthers() throws Exception {
+        Path zip = createZip("test.zip",
+                entry("file.txt", "content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Thread interruptedThread = new Thread(() -> {
+                Thread.currentThread().interrupt();
+                try {
+                    Files.readString(fs.getPath("/file.txt"));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    Thread.interrupted(); // clear flag
+                }
+            });
+            interruptedThread.start();
+            interruptedThread.join();
+
+            // Main thread should still be able to read
+            assertEquals("content", Files.readString(fs.getPath("/file.txt")));
+        }
+    }
+
+    // -- Close behavior --
+
+    @Test
+    void closeBehavior() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+        assertTrue(fs.isOpen());
+
+        fs.close();
+        assertFalse(fs.isOpen());
+
+        assertThrows(ClosedFileSystemException.class,
+                () -> Files.readAllBytes(fs.getPath("/x.txt")));
+
+        // Idempotent
+        fs.close();
+    }
+
+    // -- Empty ZIP --
+
+    @Test
+    void emptyZip() throws IOException {
+        Path zip = createZip("empty.zip");
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertTrue(Files.exists(fs.getPath("/")));
+            assertTrue(Files.isDirectory(fs.getPath("/")));
+            try (Stream<Path> stream = Files.walk(fs.getPath("/"))) {
+                List<String> paths = stream.map(Path::toString).collect(Collectors.toList());
+                assertEquals(List.of("/"), paths);
+            }
+        }
+    }
+
+    // -- Filesystem properties --
+
+    @Test
+    void filesystemProperties() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("/", fs.getSeparator());
+            assertTrue(fs.isReadOnly());
+            assertTrue(fs.supportedFileAttributeViews().contains("basic"));
+        }
+    }
+
+    // -- Via ZipUtils factory --
+
+    @Test
+    void viaZipUtilsFactory() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("hello.txt", "world"));
+
+        try (FileSystem fs = ZipUtils.openReadOnly(zip)) {
+            assertEquals("world", Files.readString(fs.getPath("/hello.txt")));
+            assertTrue(fs.isReadOnly());
+        }
+    }
+
+    // -- Multiple entries with nested directories --
+
+    @Test
+    void deeplyNestedEntries() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a/b/c/d/e.txt", "deep"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("deep", Files.readString(fs.getPath("/a/b/c/d/e.txt")));
+            assertTrue(Files.isDirectory(fs.getPath("/a")));
+            assertTrue(Files.isDirectory(fs.getPath("/a/b")));
+            assertTrue(Files.isDirectory(fs.getPath("/a/b/c")));
+            assertTrue(Files.isDirectory(fs.getPath("/a/b/c/d")));
+        }
+    }
+
+    // -- readAttributes(String) map variant --
+
+    @Test
+    void readAttributesMapAll() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "content"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var map = Files.readAttributes(fs.getPath("/f.txt"), "basic:*");
+            assertEquals(7L, map.get("size"));
+            assertEquals(true, map.get("isRegularFile"));
+            assertEquals(false, map.get("isDirectory"));
+            assertNotNull(map.get("lastModifiedTime"));
+        }
+    }
+
+    @Test
+    void readAttributesMapSpecific() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "content"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var map = Files.readAttributes(fs.getPath("/f.txt"), "size,isDirectory");
+            assertEquals(7L, map.get("size"));
+            assertEquals(false, map.get("isDirectory"));
+            assertEquals(2, map.size());
+        }
+    }
+
+    @Test
+    void readAttributesUnsupportedViewThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertThrows(UnsupportedOperationException.class,
+                    () -> Files.readAttributes(fs.getPath("/f.txt"), "posix:*"));
+        }
+    }
+
+    // -- checkAccess --
+
+    @Test
+    void checkAccessRead() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            fs.provider().checkAccess(fs.getPath("/f.txt"));
+        }
+    }
+
+    @Test
+    void checkAccessWriteThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertThrows(AccessDeniedException.class,
+                    () -> fs.provider().checkAccess(fs.getPath("/f.txt"),
+                            java.nio.file.AccessMode.WRITE));
+        }
+    }
+
+    @Test
+    void checkAccessNonExistentThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertThrows(NoSuchFileException.class,
+                    () -> fs.provider().checkAccess(fs.getPath("/missing.txt")));
+        }
+    }
+
+    // -- SeekableByteChannel --
+
+    @Test
+    void byteChannelReadAndSeek() throws IOException {
+        Path zip = createZip("test.zip", entry("data.txt", "abcdef"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                SeekableByteChannel ch = Files.newByteChannel(fs.getPath("/data.txt"))) {
+            assertEquals(6, ch.size());
+            assertEquals(0, ch.position());
+
+            ByteBuffer buf = ByteBuffer.allocate(3);
+            ch.read(buf);
+            buf.flip();
+            assertEquals("abc", StandardCharsets.UTF_8.decode(buf).toString());
+            assertEquals(3, ch.position());
+
+            ch.position(1);
+            buf.clear();
+            ch.read(buf);
+            buf.flip();
+            assertEquals("bcd", StandardCharsets.UTF_8.decode(buf).toString());
+        }
+    }
+
+    @Test
+    void byteChannelWriteThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                SeekableByteChannel ch = Files.newByteChannel(fs.getPath("/x.txt"))) {
+            assertThrows(NonWritableChannelException.class,
+                    () -> ch.write(ByteBuffer.wrap(new byte[] { 1 })));
+            assertThrows(NonWritableChannelException.class,
+                    () -> ch.truncate(0));
+        }
+    }
+
+    @Test
+    void byteChannelClosedThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            SeekableByteChannel ch = Files.newByteChannel(fs.getPath("/x.txt"));
+            ch.close();
+            assertFalse(ch.isOpen());
+            assertThrows(java.nio.channels.ClosedChannelException.class,
+                    () -> ch.read(ByteBuffer.allocate(1)));
+        }
+    }
+
+    // -- PathMatcher / glob --
+
+    @Test
+    void globMatchesSingleStar() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("Foo.class", "x"),
+                entry("Bar.txt", "y"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:*.class");
+            assertTrue(matcher.matches(fs.getPath("Foo.class")));
+            assertFalse(matcher.matches(fs.getPath("Bar.txt")));
+        }
+    }
+
+    @Test
+    void globMatchesDoubleStar() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a/b/c.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:**/*.txt");
+            assertTrue(matcher.matches(fs.getPath("a/b/c.txt")));
+            assertFalse(matcher.matches(fs.getPath("a/b/c.jar")));
+        }
+    }
+
+    @Test
+    void globDoubleStarRequiresSeparator() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:a/**/b");
+            assertTrue(matcher.matches(fs.getPath("a/b")));
+            assertTrue(matcher.matches(fs.getPath("a/x/b")));
+            assertTrue(matcher.matches(fs.getPath("a/x/y/b")));
+            assertFalse(matcher.matches(fs.getPath("a/xb")));
+        }
+    }
+
+    @Test
+    void globLeadingDoubleStarMatchesAnyDepth() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:**/Foo.class");
+            assertTrue(matcher.matches(fs.getPath("Foo.class")));
+            assertTrue(matcher.matches(fs.getPath("com/Foo.class")));
+            assertTrue(matcher.matches(fs.getPath("com/example/Foo.class")));
+            assertFalse(matcher.matches(fs.getPath("Foo.txt")));
+            assertFalse(matcher.matches(fs.getPath("com/Bar.class")));
+        }
+    }
+
+    @Test
+    void globStandaloneDoubleStarMatchesAllButNotEmpty() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:**");
+            assertTrue(matcher.matches(fs.getPath("a.txt")));
+            assertTrue(matcher.matches(fs.getPath("a/b/c.txt")));
+            assertFalse(matcher.matches(fs.getPath("")));
+        }
+    }
+
+    @Test
+    void globTrailingDoubleStarMatchesDescendants() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:a/**");
+            assertTrue(matcher.matches(fs.getPath("a/b")));
+            assertTrue(matcher.matches(fs.getPath("a/b/c")));
+            assertFalse(matcher.matches(fs.getPath("a/")));
+        }
+    }
+
+    @Test
+    void globMatchesBraceAlternation() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:*.{txt,xml}");
+            assertTrue(matcher.matches(fs.getPath("file.txt")));
+            assertTrue(matcher.matches(fs.getPath("file.xml")));
+            assertFalse(matcher.matches(fs.getPath("file.jar")));
+        }
+    }
+
+    @Test
+    void globMatchesCharacterClass() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:[abc].txt");
+            assertTrue(matcher.matches(fs.getPath("a.txt")));
+            assertFalse(matcher.matches(fs.getPath("d.txt")));
+        }
+    }
+
+    @Test
+    void globMatchesNegatedCharacterClass() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:[!abc].txt");
+            assertFalse(matcher.matches(fs.getPath("a.txt")));
+            assertTrue(matcher.matches(fs.getPath("d.txt")));
+        }
+    }
+
+    @Test
+    void globMatchesNestedBraces() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:*.{txt,{xml,json}}");
+            assertTrue(matcher.matches(fs.getPath("file.txt")));
+            assertTrue(matcher.matches(fs.getPath("file.xml")));
+            assertTrue(matcher.matches(fs.getPath("file.json")));
+            assertFalse(matcher.matches(fs.getPath("file.jar")));
+        }
+    }
+
+    @Test
+    void globMatchesEscapedCharacters() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:file\\*.txt");
+            assertTrue(matcher.matches(fs.getPath("file*.txt")));
+            assertFalse(matcher.matches(fs.getPath("fileXYZ.txt")));
+        }
+    }
+
+    @Test
+    void globMatchesQuestionMark() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("glob:?.txt");
+            assertTrue(matcher.matches(fs.getPath("a.txt")));
+            assertFalse(matcher.matches(fs.getPath("ab.txt")));
+            assertFalse(matcher.matches(fs.getPath("/.txt")));
+        }
+    }
+
+    @Test
+    void regexMatcher() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            var matcher = fs.getPathMatcher("regex:.*\\.class");
+            assertTrue(matcher.matches(fs.getPath("Foo.class")));
+            assertFalse(matcher.matches(fs.getPath("Foo.txt")));
+        }
+    }
+
+    @Test
+    void invalidPathMatcherSyntaxThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> fs.getPathMatcher("nocolon"));
+            assertThrows(UnsupportedOperationException.class,
+                    () -> fs.getPathMatcher("unknown:pattern"));
+        }
+    }
+
+    // -- Error cases --
+
+    @Test
+    void openNonZipFileThrows() throws IOException {
+        Path notZip = tempDir.resolve("not-a-zip.txt");
+        Files.writeString(notZip, "this is not a zip file");
+        assertThrows(IOException.class, () -> ReadOnlyZipFileSystem.open(notZip));
+    }
+
+    @Test
+    void openTruncatedZipThrows() throws IOException {
+        Path zip = createZip("good.zip", entry("f.txt", "data"));
+        byte[] bytes = Files.readAllBytes(zip);
+        Path truncated = tempDir.resolve("truncated.zip");
+        Files.write(truncated, java.util.Arrays.copyOf(bytes, 10));
+        assertThrows(IOException.class, () -> ReadOnlyZipFileSystem.open(truncated));
+    }
+
+    // -- Multiple simultaneous filesystems --
+
+    @Test
+    void multipleFilesystemsIsolated() throws IOException {
+        Path zip1 = createZip("one.zip", entry("a.txt", "alpha"));
+        Path zip2 = createZip("two.zip", entry("b.txt", "bravo"));
+
+        try (FileSystem fs1 = ReadOnlyZipFileSystem.open(zip1);
+                FileSystem fs2 = ReadOnlyZipFileSystem.open(zip2)) {
+            assertEquals("alpha", Files.readString(fs1.getPath("/a.txt")));
+            assertEquals("bravo", Files.readString(fs2.getPath("/b.txt")));
+            assertFalse(Files.exists(fs1.getPath("/b.txt")));
+            assertFalse(Files.exists(fs2.getPath("/a.txt")));
+        }
+    }
+
+    // -- CRC-32 verification --
+
+    @Test
+    void corruptedEntryDetected() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "hello"));
+        byte[] raw = Files.readAllBytes(zip);
+        // corrupt a byte near the end (inside the compressed data region)
+        for (int i = raw.length - 30; i < raw.length - 22; i++) {
+            raw[i] = (byte) (raw[i] ^ 0xFF);
+        }
+        Path corrupt = tempDir.resolve("corrupt.zip");
+        Files.write(corrupt, raw);
+        // parsing may fail, or reading the entry should fail with CRC/decompression error
+        assertThrows(IOException.class, () -> {
+            try (FileSystem fs = ReadOnlyZipFileSystem.open(corrupt)) {
+                Files.readAllBytes(fs.getPath("/f.txt"));
+            }
+        });
+    }
+
+    @Test
+    void unsupportedCompressionMethodThrows() throws IOException {
+        Path zip = createZip("test.zip", entry("f.txt", "hello"));
+        byte[] raw = Files.readAllBytes(zip);
+        int cdOff = findCentralDirectoryOffset(raw);
+        // patch compression method (offset 10 in CEN header) to 9 (deflate64)
+        raw[cdOff + 10] = 9;
+        raw[cdOff + 11] = 0;
+        Path patched = tempDir.resolve("unsupported-method.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            IOException ex = assertThrows(IOException.class,
+                    () -> Files.readAllBytes(fs.getPath("/f.txt")));
+            assertTrue(ex.getMessage().contains("Unsupported compression method"), ex.getMessage());
+        }
+    }
+
+    // -- Zip bomb protection --
+
+    @Test
+    void oversizedEntryRejected() throws IOException {
+        Path zip = createZip("test.zip", entry("small.txt", "ok"));
+        byte[] raw = Files.readAllBytes(zip);
+        patchCentralDirectoryUncompressedSize(raw, ReadOnlyZipFileSystem.MAX_ENTRY_SIZE + 1);
+        Path patched = tempDir.resolve("oversized.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            IOException ex = assertThrows(IOException.class,
+                    () -> Files.readAllBytes(fs.getPath("/small.txt")));
+            assertTrue(ex.getMessage().contains("Entry too large"), ex.getMessage());
+        }
+    }
+
+    @Test
+    void suspiciousCompressionRatioRejected() throws IOException {
+        Path zip = createZip("test.zip", entry("small.txt", "ok"));
+        byte[] raw = Files.readAllBytes(zip);
+        // Set uncompressed size to (compressed size * 1001) to exceed the ratio limit
+        long compressedSize = findCentralDirectoryCompressedSize(raw);
+        long fakeUncompressed = compressedSize * 1001;
+        patchCentralDirectoryUncompressedSize(raw, fakeUncompressed);
+        Path patched = tempDir.resolve("ratio.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            IOException ex = assertThrows(IOException.class,
+                    () -> Files.readAllBytes(fs.getPath("/small.txt")));
+            assertTrue(ex.getMessage().contains("Suspicious compression ratio"), ex.getMessage());
+        }
+    }
+
+    @Test
+    void deflatedEmptyEntryWithZeroUncompressedSize() throws IOException {
+        Path zip = createZip("test.zip", entry("empty.txt", ""));
+        byte[] raw = Files.readAllBytes(zip);
+        patchCentralDirectoryUncompressedSize(raw, 0);
+        Path patched = tempDir.resolve("empty-zero-size.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            assertEquals("", Files.readString(fs.getPath("/empty.txt")));
+        }
+    }
+
+    @Test
+    void deflatedEntryWithZeroUncompressedSizeInCentralDirectory() throws IOException {
+        Path zip = createZip("test.zip", entry("hello.txt", "hello world"));
+        byte[] raw = Files.readAllBytes(zip);
+        patchCentralDirectoryUncompressedSize(raw, 0);
+        Path patched = tempDir.resolve("zero-size.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            assertEquals("hello world", Files.readString(fs.getPath("/hello.txt")));
+        }
+    }
+
+    @Test
+    void inflateDynamicUsedWhenAllSizeSourcesAreZero() throws IOException {
+        // Non-empty content with non-zero CRC: the crc32==0 shortcut won't apply.
+        // Zero out uncompressed size in both headers and clear bit 3 so the data
+        // descriptor is not consulted — inflate must fall back to inflateDynamic.
+        byte[] content = new byte[10_000];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) (i % 127 + 1);
+        }
+        Path zip = createZip("test.zip", entry("big.bin", content));
+        byte[] raw = Files.readAllBytes(zip);
+        patchCentralDirectoryUncompressedSize(raw, 0);
+        patchLocalHeaderUncompressedSize(raw, 0);
+        clearLocalHeaderDataDescriptorFlag(raw);
+        Path patched = tempDir.resolve("dynamic-inflate.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            assertArrayEquals(content, Files.readAllBytes(fs.getPath("/big.bin")));
+        }
+    }
+
+    @Test
+    void dataDescriptorUncompressedSizeValidatedAgainstMaxEntrySize() throws IOException {
+        byte[] content = "small payload".getBytes(StandardCharsets.UTF_8);
+        byte[] raw = buildZipWithDataDescriptor("bomb.txt", content);
+
+        // Patch the data descriptor's uncompressed size to exceed MAX_ENTRY_SIZE.
+        // The data descriptor (with signature) starts right after compressed data.
+        // Local header: 30 + name length. Then compressed data, then DD.
+        int nameLen = "bomb.txt".length();
+        int localHeaderEnd = 30 + nameLen;
+        // Find compressed data length from the DD itself (at DD offset + 8)
+        int ddOffset = -1;
+        for (int i = localHeaderEnd; i < raw.length - 16; i++) {
+            if (readLeInt32(raw, i) == 0x08074b50) {
+                ddOffset = i;
+                break;
+            }
+        }
+        assertTrue(ddOffset > 0, "Data descriptor not found");
+        // Patch uncompressed size in DD (offset 12 from DD start) to MAX_ENTRY_SIZE + 1
+        writeLeUint32(raw, ddOffset + 12, ReadOnlyZipFileSystem.MAX_ENTRY_SIZE + 1);
+
+        Path zip = tempDir.resolve("dd-bomb.zip");
+        Files.write(zip, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            IOException ex = assertThrows(IOException.class,
+                    () -> Files.readAllBytes(fs.getPath("/bomb.txt")));
+            assertTrue(ex.getMessage().contains("Entry too large"), ex.getMessage());
+        }
+    }
+
+    @Test
+    void compressedSizeValidatedBeforeAllocation() throws IOException {
+        Path zip = createZip("test.zip", entry("small.txt", "ok"));
+        byte[] raw = Files.readAllBytes(zip);
+        // Patch compressed size in CD to just over MAX_ENTRY_SIZE
+        int cdOff = findCentralDirectoryOffset(raw);
+        writeLeUint32(raw, cdOff + 20, ReadOnlyZipFileSystem.MAX_ENTRY_SIZE + 1);
+        Path patched = tempDir.resolve("big-compressed.zip");
+        Files.write(patched, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(patched)) {
+            IOException ex = assertThrows(IOException.class,
+                    () -> Files.readAllBytes(fs.getPath("/small.txt")));
+            assertTrue(ex.getMessage().contains("Entry too large"), ex.getMessage());
+        }
+    }
+
+    @Test
+    void zip64ExtraFieldBoundedByOwnDataSize() throws IOException {
+        // Build a ZIP64 archive where the ZIP64 extra field has dataSize=8
+        // (only uncompressed size), followed by a dummy extra field whose bytes
+        // should NOT be misread as compressedSize.
+        byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+        byte[] nameBytes = "entry.txt".getBytes(StandardCharsets.UTF_8);
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        long crcValue = crc.getValue();
+
+        // ZIP64 extra: tag(2) + dataSize(2) + uncompressedSize(8) = 12 bytes, dataSize=8
+        ByteBuffer zip64Extra = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+        zip64Extra.putShort((short) 0x0001);
+        zip64Extra.putShort((short) 8); // only stores uncompressed size
+        zip64Extra.putLong(data.length);
+
+        // Dummy extra field with garbage data that would produce a wrong compressedSize
+        ByteBuffer dummyExtra = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+        dummyExtra.putShort((short) 0x9999); // unknown tag
+        dummyExtra.putShort((short) 8);
+        dummyExtra.putLong(0xDEADBEEFCAFEL); // garbage
+
+        byte[] combinedExtra = new byte[24];
+        System.arraycopy(zip64Extra.array(), 0, combinedExtra, 0, 12);
+        System.arraycopy(dummyExtra.array(), 0, combinedExtra, 12, 12);
+
+        // Verify that readZip64Extra with short dataSize does NOT read past the ZIP64 field.
+        // compressedSize should remain at 0xFFFFFFFF (unresolved) since ZIP64 field is too short.
+        long[] result = ZipCentralDirectory.readZip64Extra(
+                combinedExtra, 0, combinedExtra.length,
+                0xFFFFFFFFL, 0xFFFFFFFFL, 0);
+        assertEquals(data.length, result[0], "uncompressedSize should be read from ZIP64 field");
+        assertEquals(0xFFFFFFFFL, result[1],
+                "compressedSize should remain sentinel when ZIP64 field is too short");
+    }
+
+    @Test
+    void truncatedCentralDirectoryEntryRejected() throws IOException {
+        Path zip = createZip("test.zip", entry("hello.txt", "hello"));
+        byte[] raw = Files.readAllBytes(zip);
+        int cdOff = findCentralDirectoryOffset(raw);
+
+        // Patch the name length in the CD entry to extend past the CD buffer
+        int cdSize = raw.length - 22 - cdOff; // approximate CD size
+        int nameLen = cdSize + 10; // name extends well past buffer
+        raw[cdOff + 28] = (byte) (nameLen & 0xFF);
+        raw[cdOff + 29] = (byte) ((nameLen >> 8) & 0xFF);
+
+        Path patched = tempDir.resolve("truncated-cd.zip");
+        Files.write(patched, raw);
+
+        IOException ex = assertThrows(IOException.class,
+                () -> ReadOnlyZipFileSystem.open(patched));
+        assertTrue(ex.getMessage().contains("Truncated"), ex.getMessage());
+    }
+
+    @Test
+    void deflatedEntryWithDataDescriptorProvidesUncompressedSize() throws IOException {
+        byte[] content = "data descriptor entry".getBytes(StandardCharsets.UTF_8);
+        byte[] raw = buildZipWithDataDescriptor("dd.txt", content);
+        Path zip = tempDir.resolve("data-descriptor.zip");
+        Files.write(zip, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("data descriptor entry", Files.readString(fs.getPath("/dd.txt")));
+        }
+    }
+
+    @Test
+    void zip64EntryWithDataDescriptorProvidesUncompressedSize() throws IOException {
+        byte[] content = "zip64 data descriptor entry".getBytes(StandardCharsets.UTF_8);
+        byte[] raw = buildZip64WithDataDescriptor("dd64.txt", content);
+        Path zip = tempDir.resolve("zip64-data-descriptor.zip");
+        Files.write(zip, raw);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("zip64 data descriptor entry", Files.readString(fs.getPath("/dd64.txt")));
+        }
+    }
+
+    // -- Non-ASCII (UTF-8) entry names --
+
+    @Test
+    void readEntryWithUnicodeNames() throws IOException {
+        Path zip = createZip("unicode.zip",
+                entry("éàü.txt", "accented"),
+                entry("日本語/テスト.txt", "japanese"),
+                entry("中文.txt", "chinese"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("accented", Files.readString(fs.getPath("/éàü.txt")));
+            assertEquals("japanese", Files.readString(fs.getPath("/日本語/テスト.txt")));
+            assertEquals("chinese", Files.readString(fs.getPath("/中文.txt")));
+            assertTrue(Files.isDirectory(fs.getPath("/日本語")));
+        }
+    }
+
+    @Test
+    void toUriEncodesSpecialCharacters() throws IOException {
+        Path zip = createZip("uri.zip",
+                entry("with space.txt", "s"),
+                entry("file#1.txt", "h"),
+                entry("café.txt", "c"),
+                entry("q?mark.txt", "q"),
+                entry("pct%val.txt", "p"),
+                entry("a&b=c.txt", "a"),
+                entry("dir/nested file.txt", "n"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            java.net.URI spaceUri = fs.getPath("/with space.txt").toUri();
+            assertTrue(spaceUri.toString().contains("with%20space.txt"),
+                    "Space should be percent-encoded: " + spaceUri);
+
+            java.net.URI hashUri = fs.getPath("/file#1.txt").toUri();
+            assertTrue(hashUri.toString().contains("file%231.txt"),
+                    "Hash should be percent-encoded: " + hashUri);
+
+            java.net.URI cafeUri = fs.getPath("/café.txt").toUri();
+            assertNotNull(cafeUri);
+            assertTrue(cafeUri.toString().contains("café.txt"),
+                    "Non-ASCII is valid in IRIs: " + cafeUri);
+
+            java.net.URI questionUri = fs.getPath("/q?mark.txt").toUri();
+            assertTrue(questionUri.toString().contains("q%3Fmark.txt"),
+                    "Question mark should be percent-encoded: " + questionUri);
+
+            java.net.URI pctUri = fs.getPath("/pct%val.txt").toUri();
+            assertTrue(pctUri.toString().contains("pct%25val.txt"),
+                    "Percent sign should be percent-encoded: " + pctUri);
+
+            java.net.URI ampUri = fs.getPath("/a&b=c.txt").toUri();
+            assertTrue(ampUri.toString().contains("a&b=c.txt"),
+                    "Ampersand and equals are valid URI chars: " + ampUri);
+
+            java.net.URI nestedUri = fs.getPath("/dir/nested file.txt").toUri();
+            assertTrue(nestedUri.toString().contains("dir/nested%20file.txt"),
+                    "Nested path should preserve slashes and encode spaces: " + nestedUri);
+        }
+    }
+
+    @Test
+    void toUriProducesValidJarScheme() throws IOException {
+        Path zip = createZip("uri.zip", entry("a.txt", "a"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            java.net.URI uri = fs.getPath("/a.txt").toUri();
+            assertTrue(uri.toString().startsWith("jar:file:"),
+                    "URI should start with jar:file: " + uri);
+            assertTrue(uri.toString().contains("!/a.txt"),
+                    "URI should contain !/ separator: " + uri);
+        }
+    }
+
+    // -- isSameFile --
+
+    @Test
+    void isSameFileSamePath() throws IOException {
+        Path zip = createZip("test.zip", entry("a.txt", "a"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("/a.txt");
+            assertTrue(fs.provider().isSameFile(p, p));
+        }
+    }
+
+    @Test
+    void isSameFileEqualPaths() throws IOException {
+        Path zip = createZip("test.zip", entry("a.txt", "a"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p1 = fs.getPath("/a.txt");
+            Path p2 = fs.getPath("/a.txt");
+            assertTrue(fs.provider().isSameFile(p1, p2));
+        }
+    }
+
+    @Test
+    void isSameFileNormalizedPaths() throws IOException {
+        Path zip = createZip("test.zip", entry("a/b.txt", "b"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p1 = fs.getPath("/a/b.txt");
+            Path p2 = fs.getPath("/a/c/../b.txt");
+            assertTrue(fs.provider().isSameFile(p1, p2));
+        }
+    }
+
+    @Test
+    void isSameFileDifferentArchives() throws IOException {
+        Path zip1 = createZip("one.zip", entry("a.txt", "a"));
+        Path zip2 = createZip("two.zip", entry("a.txt", "a"));
+        try (FileSystem fs1 = ReadOnlyZipFileSystem.open(zip1);
+                FileSystem fs2 = ReadOnlyZipFileSystem.open(zip2)) {
+            assertFalse(fs1.provider().isSameFile(fs1.getPath("/a.txt"), fs2.getPath("/a.txt")));
+        }
+    }
+
+    @Test
+    void isSameFileSameArchiveDifferentInstances() throws IOException {
+        Path zip = createZip("test.zip", entry("a.txt", "a"));
+        try (FileSystem fs1 = ReadOnlyZipFileSystem.open(zip);
+                FileSystem fs2 = ReadOnlyZipFileSystem.open(zip)) {
+            assertTrue(fs1.provider().isSameFile(fs1.getPath("/a.txt"), fs2.getPath("/a.txt")));
+            assertTrue(fs1.provider().isSameFile(fs1.getPath("/a.txt"), fs2.getPath("/b/../a.txt")));
+            assertFalse(fs1 == fs2, "Filesystem instances should be distinct");
+        }
+    }
+
+    @Test
+    void isSameFileDifferentPaths() throws IOException {
+        Path zip = createZip("test.zip", entry("a.txt", "a"), entry("b.txt", "b"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertFalse(fs.provider().isSameFile(fs.getPath("/a.txt"), fs.getPath("/b.txt")));
+        }
+    }
+
+    // -- ZIP64 --
+
+    @Test
+    void readZip64Archive() throws IOException {
+        byte[] content = "zip64 content".getBytes(StandardCharsets.UTF_8);
+        Path zip64 = tempDir.resolve("zip64.zip");
+        Files.write(zip64, buildZip64Archive("hello.txt", content));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip64)) {
+            assertEquals("zip64 content", Files.readString(fs.getPath("/hello.txt")));
+            assertTrue(Files.isRegularFile(fs.getPath("/hello.txt")));
+            BasicFileAttributes attrs = Files.readAttributes(
+                    fs.getPath("/hello.txt"), BasicFileAttributes.class);
+            assertEquals(content.length, attrs.size());
+        }
+    }
+
+    // -- Extended timestamps --
+
+    @Test
+    void readsUnixExtendedTimestamp() throws IOException {
+        // Odd second — DOS time has 2-second granularity, so second-level
+        // precision proves the Unix extended timestamp (0x5455) was read.
+        Instant timestamp = Instant.parse("2024-06-15T10:30:45Z");
+
+        Path zip = tempDir.resolve("timestamps.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            ZipEntry ze = new ZipEntry("file.txt");
+            ze.setLastModifiedTime(FileTime.from(timestamp));
+            zos.putNextEntry(ze);
+            zos.write("content".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            BasicFileAttributes attrs = Files.readAttributes(
+                    fs.getPath("/file.txt"), BasicFileAttributes.class);
+            long actualEpochSecond = attrs.lastModifiedTime().toInstant().getEpochSecond();
+            assertEquals(timestamp.getEpochSecond(), actualEpochSecond,
+                    "Extended timestamp should preserve second-level precision");
+        }
+    }
+
+    @Test
+    void readsNtfsTimestamp() throws IOException {
+        // Build a ZIP with an NTFS extra field (tag 0x000a) containing a known timestamp
+        Instant expected = Instant.parse("2024-03-20T14:30:00Z");
+        long expectedMillis = expected.toEpochMilli();
+        // Windows FILETIME: 100-nanosecond intervals since 1601-01-01
+        long winTime = (expectedMillis + 11_644_473_600_000L) * 10_000L;
+
+        byte[] content = "ntfs".getBytes(StandardCharsets.UTF_8);
+        Path zip = tempDir.resolve("ntfs.zip");
+        Files.write(zip, buildZipWithNtfsTimestamp("file.txt", content, winTime));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            BasicFileAttributes attrs = Files.readAttributes(
+                    fs.getPath("/file.txt"), BasicFileAttributes.class);
+            assertEquals(expectedMillis, attrs.lastModifiedTime().toMillis(),
+                    "NTFS timestamp should be read from extra field");
+        }
+    }
+
+    // -- Reading a directory entry --
+
+    @Test
+    void readImplicitDirectoryEntryThrows() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("dir/file.txt", "content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            FileSystemException ex = assertThrows(FileSystemException.class,
+                    () -> Files.readAllBytes(fs.getPath("/dir")));
+            assertTrue(ex.getReason().contains("directory"), ex.getReason());
+        }
+    }
+
+    @Test
+    void readExplicitDirectoryEntryThrows() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("dir/", new byte[0]),
+                entry("dir/file.txt", "content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            FileSystemException ex = assertThrows(FileSystemException.class,
+                    () -> Files.readAllBytes(fs.getPath("/dir")));
+            assertTrue(ex.getReason().contains("directory"), ex.getReason());
+        }
+    }
+
+    // -- toRealPath --
+
+    @Test
+    void toRealPathNormalizesAndAbsolutes() throws IOException {
+        Path zip = createZip("test.zip", entry("a/b.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("a/./c/../b.txt");
+            Path real = p.toRealPath();
+            assertTrue(real.isAbsolute());
+            assertEquals("/a/b.txt", real.toString());
+        }
+    }
+
+    // -- Lookup with unnormalized paths --
+
+    @Test
+    void lookupWithDotDotSegments() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a/b.txt", "content"),
+                entry("a/c/d.txt", "deep"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("content", Files.readString(fs.getPath("/a/c/../b.txt")));
+            assertEquals("deep", Files.readString(fs.getPath("/a/c/./d.txt")));
+            assertTrue(Files.exists(fs.getPath("/a/c/../c/d.txt")));
+            assertTrue(Files.isDirectory(fs.getPath("/a/c/..")));
+        }
+    }
+
+    // -- resolveSibling --
+
+    @Test
+    void resolveSiblingPath() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("/a/b.txt");
+            Path sibling = p.resolveSibling(fs.getPath("c.txt"));
+            assertEquals("/a/c.txt", sibling.toString());
+        }
+    }
+
+    @Test
+    void resolveSiblingString() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path p = fs.getPath("/a/b.txt");
+            Path sibling = p.resolveSibling("c.txt");
+            assertEquals("/a/c.txt", sibling.toString());
+        }
+    }
+
+    @Test
+    void resolveSiblingOnRootReturnsOther() throws IOException {
+        Path zip = createZip("test.zip", entry("x.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            Path root = fs.getPath("/");
+            Path sibling = root.resolveSibling("c.txt");
+            assertEquals("c.txt", sibling.toString());
+        }
+    }
+
+    // -- Path traversal --
+
+    @Test
+    void pathTraversalEntryIsContained() throws IOException {
+        Path zip = createZip("traversal.zip",
+                entry("../../etc/passwd", "root:x:0:0"),
+                entry("a/../b.txt", "b"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            // Paths with ".." segments are normalized before lookup, so entries
+            // whose raw names contain traversal sequences are not reachable
+            // via their literal path.
+            assertThrows(NoSuchFileException.class,
+                    () -> Files.readString(fs.getPath("/../../etc/passwd")));
+
+            // "a/../b.txt" normalizes to "b.txt" which doesn't exist as an entry
+            assertThrows(NoSuchFileException.class,
+                    () -> Files.readString(fs.getPath("/a/../b.txt")));
+
+            // normalize does not escape the archive
+            Path normalized = fs.getPath("/../../etc/passwd").normalize();
+            assertTrue(normalized.toString().startsWith("/"),
+                    "Normalized path should stay within the archive: " + normalized);
+        }
+    }
+
+    // -- Mixed compression methods --
+
+    @Test
+    void mixedStoredAndDeflated() throws IOException {
+        Path zip = createZipMixedMethods("mixed.zip",
+                storedEntry("stored.txt", "stored content"),
+                deflatedEntry("deflated.txt", "deflated content"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("stored content", Files.readString(fs.getPath("/stored.txt")));
+            assertEquals("deflated content", Files.readString(fs.getPath("/deflated.txt")));
+        }
+    }
+
+    // -- Large number of entries --
+
+    @Test
+    void manyEntries() throws IOException {
+        int count = 10_000;
+        TestEntry[] entries = new TestEntry[count];
+        for (int i = 0; i < count; i++) {
+            entries[i] = entry("entry" + i + ".txt", "data" + i);
+        }
+        Path zip = createZip("many.zip", entries);
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("data0", Files.readString(fs.getPath("/entry0.txt")));
+            assertEquals("data9999", Files.readString(fs.getPath("/entry9999.txt")));
+            assertFalse(Files.exists(fs.getPath("/entry10000.txt")));
+            try (Stream<Path> stream = Files.list(fs.getPath("/"))) {
+                assertEquals(count, stream.count());
+            }
+        }
+    }
+
+    // -- getPath with empty strings --
+
+    @Test
+    void getPathWithEmptyStrings() throws IOException {
+        Path zip = createZip("test.zip", entry("a/b.txt", "x"));
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertEquals("a/b.txt", fs.getPath("a", "", "b.txt").toString());
+            assertEquals("a", fs.getPath("", "a").toString());
+            assertEquals("", fs.getPath("").toString());
+            assertEquals("", fs.getPath("", "").toString());
+        }
+    }
+
+    // -- Direct API --
+
+    @Test
+    void entryExistsDirectApi() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("a.txt", "alpha"),
+                entry("dir/b.txt", "bravo"));
+
+        try (ReadOnlyZipFileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertTrue(fs.entryExists("a.txt"));
+            assertTrue(fs.entryExists("dir/b.txt"));
+            assertTrue(fs.entryExists("dir"));
+            assertTrue(fs.entryExists(""));
+            assertFalse(fs.entryExists("missing.txt"));
+            assertFalse(fs.entryExists("dir/missing.txt"));
+        }
+    }
+
+    @Test
+    void entryExistsWithTrailingSlash() throws IOException {
+        Path zip = createZip("test.zip",
+                entry("dir/file.txt", "content"));
+
+        try (ReadOnlyZipFileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            assertTrue(fs.entryExists("dir"));
+            assertTrue(fs.entryExists("dir/"));
+            assertTrue(fs.entryExists(""));
+            assertTrue(fs.entryExists("/"));
+        }
+    }
+
+    // -- Helper methods --
+
+    // -- Entry caching --
+
+    @Test
+    void cacheReturnsIdenticalContent() throws IOException {
+        ReadOnlyZipFileSystem.CACHE_ENABLED = true;
+        Path zip = createZip("cache.zip",
+                entry("a.txt", "alpha"),
+                entry("b.txt", "bravo"));
+
+        try (ReadOnlyZipFileSystem fs = ReadOnlyZipFileSystem.open(zip)) {
+            byte[] first = fs.readEntryData("a.txt");
+            byte[] second = fs.readEntryData("a.txt");
+            assertArrayEquals(first, second);
+
+            byte[] b1 = fs.readEntryData("b.txt");
+            assertFalse(Arrays.equals(first, b1));
+        }
+    }
+
+    private Path createZip(String name, TestEntry... entries) throws IOException {
+        return createZipWithMethod(name, ZipEntry.DEFLATED, entries);
+    }
+
+    private Path createZipWithMethod(String name, int method, TestEntry... entries)
+            throws IOException {
+        Path zip = tempDir.resolve(name);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            for (TestEntry te : entries) {
+                ZipEntry ze = new ZipEntry(te.name);
+                if (method == ZipEntry.STORED) {
+                    ze.setMethod(ZipEntry.STORED);
+                    ze.setSize(te.data.length);
+                    ze.setCompressedSize(te.data.length);
+                    java.util.zip.CRC32 crc = new java.util.zip.CRC32();
+                    crc.update(te.data);
+                    ze.setCrc(crc.getValue());
+                }
+                zos.putNextEntry(ze);
+                zos.write(te.data);
+                zos.closeEntry();
+            }
+        }
+        return zip;
+    }
+
+    private static TestEntry entry(String name, String content) {
+        return new TestEntry(name, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static TestEntry entry(String name, byte[] data) {
+        return new TestEntry(name, data);
+    }
+
+    private record TestEntry(String name, byte[] data) {
+    }
+
+    private record MethodEntry(String name, byte[] data, int method) {
+    }
+
+    private static MethodEntry storedEntry(String name, String content) {
+        return new MethodEntry(name, content.getBytes(StandardCharsets.UTF_8), ZipEntry.STORED);
+    }
+
+    private static MethodEntry deflatedEntry(String name, String content) {
+        return new MethodEntry(name, content.getBytes(StandardCharsets.UTF_8), ZipEntry.DEFLATED);
+    }
+
+    private Path createZipMixedMethods(String name, MethodEntry... entries) throws IOException {
+        Path zip = tempDir.resolve(name);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip))) {
+            for (MethodEntry me : entries) {
+                ZipEntry ze = new ZipEntry(me.name);
+                ze.setMethod(me.method);
+                if (me.method == ZipEntry.STORED) {
+                    ze.setSize(me.data.length);
+                    ze.setCompressedSize(me.data.length);
+                    CRC32 crc = new CRC32();
+                    crc.update(me.data);
+                    ze.setCrc(crc.getValue());
+                }
+                zos.putNextEntry(ze);
+                zos.write(me.data);
+                zos.closeEntry();
+            }
+        }
+        return zip;
+    }
+
+    private static final int CENTRAL_DIR_SIG = 0x02014b50;
+
+    private static int findCentralDirectoryOffset(byte[] zip) {
+        for (int i = zip.length - 22; i >= 0; i--) {
+            if (readLeInt32(zip, i) == 0x06054b50) {
+                return (int) readLeUint32(zip, i + 16);
+            }
+        }
+        throw new IllegalStateException("EOCD not found");
+    }
+
+    private static void patchCentralDirectoryUncompressedSize(byte[] zip, long newSize) {
+        int cdOff = findCentralDirectoryOffset(zip);
+        if (readLeInt32(zip, cdOff) != CENTRAL_DIR_SIG) {
+            throw new IllegalStateException("Not a central directory entry at offset " + cdOff);
+        }
+        writeLeUint32(zip, cdOff + 24, newSize);
+    }
+
+    private static void clearLocalHeaderDataDescriptorFlag(byte[] zip) {
+        if (readLeInt32(zip, 0) != 0x04034b50) {
+            throw new IllegalStateException("Not a local file header at offset 0");
+        }
+        // Clear bit 3 of the general-purpose flags at local header offset 6
+        zip[6] = (byte) (zip[6] & ~0x08);
+    }
+
+    private static void patchLocalHeaderUncompressedSize(byte[] zip, long newSize) {
+        if (readLeInt32(zip, 0) != 0x04034b50) {
+            throw new IllegalStateException("Not a local file header at offset 0");
+        }
+        writeLeUint32(zip, 22, newSize);
+    }
+
+    private static long findCentralDirectoryCompressedSize(byte[] zip) {
+        int cdOff = findCentralDirectoryOffset(zip);
+        return readLeUint32(zip, cdOff + 20);
+    }
+
+    private static int readLeInt32(byte[] buf, int off) {
+        return (buf[off] & 0xFF)
+                | ((buf[off + 1] & 0xFF) << 8)
+                | ((buf[off + 2] & 0xFF) << 16)
+                | ((buf[off + 3] & 0xFF) << 24);
+    }
+
+    private static long readLeUint32(byte[] buf, int off) {
+        return readLeInt32(buf, off) & 0xFFFFFFFFL;
+    }
+
+    private static void writeLeUint32(byte[] buf, int off, long value) {
+        buf[off] = (byte) (value & 0xFF);
+        buf[off + 1] = (byte) ((value >> 8) & 0xFF);
+        buf[off + 2] = (byte) ((value >> 16) & 0xFF);
+        buf[off + 3] = (byte) ((value >> 24) & 0xFF);
+    }
+
+    /**
+     * Builds a minimal ZIP64 archive with one STORED entry. The archive uses
+     * ZIP64 sentinel values (0xFFFFFFFF) in the central directory and EOCD,
+     * with actual values in the ZIP64 extra fields and ZIP64 EOCD record.
+     */
+    private static byte[] buildZip64Archive(String entryName, byte[] data) throws IOException {
+        byte[] nameBytes = entryName.getBytes(StandardCharsets.UTF_8);
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        long crcValue = crc.getValue();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // -- Local file header --
+        long localHeaderOffset = 0;
+        // ZIP64 extra field: uncompressed size (8) + compressed size (8)
+        byte[] localExtra = buildZip64ExtraField(data.length, data.length);
+
+        ByteBuffer local = ByteBuffer.allocate(30 + nameBytes.length + localExtra.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        local.putInt(0x04034b50); // local file header signature
+        local.putShort((short) 45); // version needed (4.5 for ZIP64)
+        local.putShort((short) 0); // general purpose bit flag
+        local.putShort((short) 0); // compression method: STORED
+        local.putShort((short) 0); // last mod file time
+        local.putShort((short) 0); // last mod file date
+        local.putInt((int) crcValue); // crc-32
+        local.putInt(0xFFFFFFFF); // compressed size (ZIP64 sentinel)
+        local.putInt(0xFFFFFFFF); // uncompressed size (ZIP64 sentinel)
+        local.putShort((short) nameBytes.length);
+        local.putShort((short) localExtra.length);
+        local.put(nameBytes);
+        local.put(localExtra);
+        out.write(local.array());
+        out.write(data);
+
+        // -- Central directory header --
+        long cdOffset = out.size();
+        // ZIP64 extra field: uncompressed size (8) + compressed size (8) + local header offset (8)
+        byte[] cdExtra = buildZip64ExtraFieldWithOffset(data.length, data.length, localHeaderOffset);
+
+        ByteBuffer cd = ByteBuffer.allocate(46 + nameBytes.length + cdExtra.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        cd.putInt(CENTRAL_DIR_SIG); // central directory signature
+        cd.putShort((short) 45); // version made by
+        cd.putShort((short) 45); // version needed
+        cd.putShort((short) 0); // general purpose bit flag
+        cd.putShort((short) 0); // compression method: STORED
+        cd.putShort((short) 0); // last mod file time
+        cd.putShort((short) 0); // last mod file date
+        cd.putInt((int) crcValue); // crc-32
+        cd.putInt(0xFFFFFFFF); // compressed size (ZIP64 sentinel)
+        cd.putInt(0xFFFFFFFF); // uncompressed size (ZIP64 sentinel)
+        cd.putShort((short) nameBytes.length);
+        cd.putShort((short) cdExtra.length); // extra field length
+        cd.putShort((short) 0); // file comment length
+        cd.putShort((short) 0); // disk number start
+        cd.putShort((short) 0); // internal file attributes
+        cd.putInt(0); // external file attributes
+        cd.putInt(0xFFFFFFFF); // local header offset (ZIP64 sentinel)
+        cd.put(nameBytes);
+        cd.put(cdExtra);
+        out.write(cd.array());
+
+        long cdSize = out.size() - cdOffset;
+
+        // -- ZIP64 End of Central Directory record --
+        long zip64EocdOffset = out.size();
+        ByteBuffer zip64Eocd = ByteBuffer.allocate(56).order(ByteOrder.LITTLE_ENDIAN);
+        zip64Eocd.putInt(0x06064b50); // ZIP64 EOCD signature
+        zip64Eocd.putLong(44); // size of remaining record
+        zip64Eocd.putShort((short) 45); // version made by
+        zip64Eocd.putShort((short) 45); // version needed
+        zip64Eocd.putInt(0); // this disk number
+        zip64Eocd.putInt(0); // disk with CD start
+        zip64Eocd.putLong(1); // total entries on this disk
+        zip64Eocd.putLong(1); // total entries
+        zip64Eocd.putLong(cdSize); // central directory size
+        zip64Eocd.putLong(cdOffset); // central directory offset
+        out.write(zip64Eocd.array());
+
+        // -- ZIP64 End of Central Directory locator --
+        ByteBuffer locator = ByteBuffer.allocate(20).order(ByteOrder.LITTLE_ENDIAN);
+        locator.putInt(0x07064b50); // ZIP64 EOCD locator signature
+        locator.putInt(0); // disk with ZIP64 EOCD
+        locator.putLong(zip64EocdOffset);
+        locator.putInt(1); // total number of disks
+        out.write(locator.array());
+
+        // -- End of Central Directory record --
+        ByteBuffer eocd = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN);
+        eocd.putInt(0x06054b50); // EOCD signature
+        eocd.putShort((short) 0); // this disk number
+        eocd.putShort((short) 0); // disk with CD start
+        eocd.putShort((short) 0xFFFF); // entries on this disk (ZIP64 sentinel)
+        eocd.putShort((short) 0xFFFF); // total entries (ZIP64 sentinel)
+        eocd.putInt(0xFFFFFFFF); // CD size (ZIP64 sentinel)
+        eocd.putInt(0xFFFFFFFF); // CD offset (ZIP64 sentinel)
+        eocd.putShort((short) 0); // comment length
+        out.write(eocd.array());
+
+        return out.toByteArray();
+    }
+
+    private static byte[] buildZip64ExtraField(long uncompressedSize, long compressedSize) {
+        ByteBuffer buf = ByteBuffer.allocate(20).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putShort((short) 0x0001); // ZIP64 extra field tag
+        buf.putShort((short) 16); // data size
+        buf.putLong(uncompressedSize);
+        buf.putLong(compressedSize);
+        return buf.array();
+    }
+
+    private static byte[] buildZip64ExtraFieldWithOffset(long uncompressedSize, long compressedSize,
+            long localHeaderOffset) {
+        ByteBuffer buf = ByteBuffer.allocate(28).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putShort((short) 0x0001); // ZIP64 extra field tag
+        buf.putShort((short) 24); // data size
+        buf.putLong(uncompressedSize);
+        buf.putLong(compressedSize);
+        buf.putLong(localHeaderOffset);
+        return buf.array();
+    }
+
+    /**
+     * Builds a minimal STORED ZIP archive with one entry that has an NTFS
+     * extra field (tag 0x000a) containing the given Windows FILETIME mtime.
+     */
+    private static byte[] buildZipWithNtfsTimestamp(String entryName, byte[] data, long winTime)
+            throws IOException {
+        byte[] nameBytes = entryName.getBytes(StandardCharsets.UTF_8);
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        long crcValue = crc.getValue();
+
+        // NTFS extra field: tag(2) + size(2) + reserved(4) + attrTag(2) + attrSize(2) + mtime(8) + atime(8) + ctime(8)
+        ByteBuffer ntfsExtra = ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN);
+        ntfsExtra.putShort((short) 0x000a); // NTFS tag
+        ntfsExtra.putShort((short) 32); // data size
+        ntfsExtra.putInt(0); // reserved
+        ntfsExtra.putShort((short) 0x0001); // attribute tag
+        ntfsExtra.putShort((short) 24); // attribute size
+        ntfsExtra.putLong(winTime); // mtime
+        ntfsExtra.putLong(winTime); // atime
+        ntfsExtra.putLong(winTime); // ctime
+        byte[] extra = ntfsExtra.array();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Local file header
+        ByteBuffer local = ByteBuffer.allocate(30 + nameBytes.length + extra.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        local.putInt(0x04034b50);
+        local.putShort((short) 20); // version needed
+        local.putShort((short) 0); // flags
+        local.putShort((short) 0); // method: STORED
+        local.putShort((short) 0); // DOS time
+        local.putShort((short) 0); // DOS date
+        local.putInt((int) crcValue);
+        local.putInt(data.length); // compressed size
+        local.putInt(data.length); // uncompressed size
+        local.putShort((short) nameBytes.length);
+        local.putShort((short) extra.length);
+        local.put(nameBytes);
+        local.put(extra);
+        out.write(local.array());
+        out.write(data);
+
+        // Central directory
+        long cdOffset = out.size();
+        ByteBuffer cd = ByteBuffer.allocate(46 + nameBytes.length + extra.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        cd.putInt(CENTRAL_DIR_SIG);
+        cd.putShort((short) 20); // version made by
+        cd.putShort((short) 20); // version needed
+        cd.putShort((short) 0); // flags
+        cd.putShort((short) 0); // method: STORED
+        cd.putShort((short) 0); // DOS time
+        cd.putShort((short) 0); // DOS date
+        cd.putInt((int) crcValue);
+        cd.putInt(data.length); // compressed size
+        cd.putInt(data.length); // uncompressed size
+        cd.putShort((short) nameBytes.length);
+        cd.putShort((short) extra.length); // extra field length
+        cd.putShort((short) 0); // comment length
+        cd.putShort((short) 0); // disk number start
+        cd.putShort((short) 0); // internal attrs
+        cd.putInt(0); // external attrs
+        cd.putInt(0); // local header offset
+        cd.put(nameBytes);
+        cd.put(extra);
+        out.write(cd.array());
+
+        long cdSize = out.size() - cdOffset;
+
+        // EOCD
+        ByteBuffer eocd = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN);
+        eocd.putInt(0x06054b50);
+        eocd.putShort((short) 0);
+        eocd.putShort((short) 0);
+        eocd.putShort((short) 1); // entries on this disk
+        eocd.putShort((short) 1); // total entries
+        eocd.putInt((int) cdSize);
+        eocd.putInt((int) cdOffset);
+        eocd.putShort((short) 0);
+        out.write(eocd.array());
+
+        return out.toByteArray();
+    }
+
+    /**
+     * Builds a minimal DEFLATED ZIP archive with one entry that uses a data
+     * descriptor (general-purpose bit 3 set). Sizes and CRC are zeroed in both
+     * the local and central directory headers; the actual values appear only in
+     * the data descriptor following the compressed data.
+     */
+    private static byte[] buildZipWithDataDescriptor(String entryName, byte[] data) throws IOException {
+        byte[] nameBytes = entryName.getBytes(StandardCharsets.UTF_8);
+
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        long crcValue = crc.getValue();
+
+        Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        deflater.setInput(data);
+        deflater.finish();
+        byte[] compBuf = new byte[data.length + 256];
+        int compLen = deflater.deflate(compBuf);
+        deflater.end();
+        byte[] compressed = new byte[compLen];
+        System.arraycopy(compBuf, 0, compressed, 0, compLen);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // -- Local file header (sizes and CRC zeroed, bit 3 set) --
+        ByteBuffer local = ByteBuffer.allocate(30 + nameBytes.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        local.putInt(0x04034b50);
+        local.putShort((short) 20); // version needed
+        local.putShort((short) 0x08); // flags: bit 3 = data descriptor
+        local.putShort((short) 8); // method: DEFLATED
+        local.putShort((short) 0); // DOS time
+        local.putShort((short) 0); // DOS date
+        local.putInt(0); // CRC-32 (deferred to data descriptor)
+        local.putInt(0); // compressed size (deferred)
+        local.putInt(0); // uncompressed size (deferred)
+        local.putShort((short) nameBytes.length);
+        local.putShort((short) 0); // extra field length
+        local.put(nameBytes);
+        out.write(local.array());
+        out.write(compressed);
+
+        // -- Data descriptor (with signature) --
+        ByteBuffer dd = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+        dd.putInt(0x08074b50); // data descriptor signature
+        dd.putInt((int) crcValue);
+        dd.putInt(compLen); // compressed size
+        dd.putInt(data.length); // uncompressed size
+        out.write(dd.array());
+
+        // -- Central directory (sizes zeroed, bit 3 set) --
+        long cdOffset = out.size();
+        ByteBuffer cd = ByteBuffer.allocate(46 + nameBytes.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        cd.putInt(CENTRAL_DIR_SIG);
+        cd.putShort((short) 20); // version made by
+        cd.putShort((short) 20); // version needed
+        cd.putShort((short) 0x08); // flags: bit 3
+        cd.putShort((short) 8); // method: DEFLATED
+        cd.putShort((short) 0); // DOS time
+        cd.putShort((short) 0); // DOS date
+        cd.putInt((int) crcValue); // CRC-32 (required for verification)
+        cd.putInt(compLen); // compressed size (required to read data)
+        cd.putInt(0); // uncompressed size (zeroed)
+        cd.putShort((short) nameBytes.length);
+        cd.putShort((short) 0); // extra field length
+        cd.putShort((short) 0); // comment length
+        cd.putShort((short) 0); // disk number start
+        cd.putShort((short) 0); // internal attrs
+        cd.putInt(0); // external attrs
+        cd.putInt(0); // local header offset
+        cd.put(nameBytes);
+        out.write(cd.array());
+
+        long cdSize = out.size() - cdOffset;
+
+        // -- EOCD --
+        ByteBuffer eocd = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN);
+        eocd.putInt(0x06054b50);
+        eocd.putShort((short) 0);
+        eocd.putShort((short) 0);
+        eocd.putShort((short) 1);
+        eocd.putShort((short) 1);
+        eocd.putInt((int) cdSize);
+        eocd.putInt((int) cdOffset);
+        eocd.putShort((short) 0);
+        out.write(eocd.array());
+
+        return out.toByteArray();
+    }
+
+    /**
+     * Builds a minimal ZIP64 DEFLATED archive with one entry that uses a
+     * data descriptor with 64-bit fields. Version needed is 45 (ZIP64),
+     * sizes are zeroed in both headers, and the actual values appear only
+     * in the ZIP64 data descriptor.
+     */
+    private static byte[] buildZip64WithDataDescriptor(String entryName, byte[] data) throws IOException {
+        byte[] nameBytes = entryName.getBytes(StandardCharsets.UTF_8);
+
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        long crcValue = crc.getValue();
+
+        Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        deflater.setInput(data);
+        deflater.finish();
+        byte[] compBuf = new byte[data.length + 256];
+        int compLen = deflater.deflate(compBuf);
+        deflater.end();
+        byte[] compressed = new byte[compLen];
+        System.arraycopy(compBuf, 0, compressed, 0, compLen);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // -- Local file header (version 45, bit 3 set, sizes zeroed) --
+        ByteBuffer local = ByteBuffer.allocate(30 + nameBytes.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        local.putInt(0x04034b50);
+        local.putShort((short) 45); // version needed (ZIP64)
+        local.putShort((short) 0x08); // flags: bit 3 = data descriptor
+        local.putShort((short) 8); // method: DEFLATED
+        local.putShort((short) 0); // DOS time
+        local.putShort((short) 0); // DOS date
+        local.putInt(0); // CRC-32 (deferred)
+        local.putInt(0); // compressed size (deferred)
+        local.putInt(0); // uncompressed size (deferred)
+        local.putShort((short) nameBytes.length);
+        local.putShort((short) 0); // extra field length
+        local.put(nameBytes);
+        out.write(local.array());
+        out.write(compressed);
+
+        // -- ZIP64 data descriptor (with signature) --
+        // signature(4) + crc32(4) + compressedSize(8) + uncompressedSize(8)
+        ByteBuffer dd = ByteBuffer.allocate(24).order(ByteOrder.LITTLE_ENDIAN);
+        dd.putInt(0x08074b50); // data descriptor signature
+        dd.putInt((int) crcValue);
+        dd.putLong(compLen); // compressed size (64-bit)
+        dd.putLong(data.length); // uncompressed size (64-bit)
+        out.write(dd.array());
+
+        // -- Central directory (ZIP64 sentinels + extra field, bit 3 set) --
+        long cdOffset = out.size();
+        byte[] cdExtra = buildZip64ExtraFieldWithOffset(0, 0, 0);
+        ByteBuffer cd = ByteBuffer.allocate(46 + nameBytes.length + cdExtra.length)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        cd.putInt(CENTRAL_DIR_SIG);
+        cd.putShort((short) 45); // version made by
+        cd.putShort((short) 45); // version needed
+        cd.putShort((short) 0x08); // flags: bit 3
+        cd.putShort((short) 8); // method: DEFLATED
+        cd.putShort((short) 0); // DOS time
+        cd.putShort((short) 0); // DOS date
+        cd.putInt((int) crcValue);
+        cd.putInt(compLen); // compressed size (needed to read data)
+        cd.putInt(0); // uncompressed size (zeroed — resolved from data descriptor)
+        cd.putShort((short) nameBytes.length);
+        cd.putShort((short) cdExtra.length);
+        cd.putShort((short) 0); // comment length
+        cd.putShort((short) 0); // disk number start
+        cd.putShort((short) 0); // internal attrs
+        cd.putInt(0); // external attrs
+        cd.putInt(0xFFFFFFFF); // local header offset (ZIP64 sentinel)
+        cd.put(nameBytes);
+        cd.put(cdExtra);
+        out.write(cd.array());
+
+        long cdSize = out.size() - cdOffset;
+
+        // -- ZIP64 EOCD --
+        long zip64EocdOffset = out.size();
+        ByteBuffer zip64Eocd = ByteBuffer.allocate(56).order(ByteOrder.LITTLE_ENDIAN);
+        zip64Eocd.putInt(0x06064b50);
+        zip64Eocd.putLong(44);
+        zip64Eocd.putShort((short) 45);
+        zip64Eocd.putShort((short) 45);
+        zip64Eocd.putInt(0);
+        zip64Eocd.putInt(0);
+        zip64Eocd.putLong(1);
+        zip64Eocd.putLong(1);
+        zip64Eocd.putLong(cdSize);
+        zip64Eocd.putLong(cdOffset);
+        out.write(zip64Eocd.array());
+
+        // -- ZIP64 EOCD locator --
+        ByteBuffer locator = ByteBuffer.allocate(20).order(ByteOrder.LITTLE_ENDIAN);
+        locator.putInt(0x07064b50);
+        locator.putInt(0);
+        locator.putLong(zip64EocdOffset);
+        locator.putInt(1);
+        out.write(locator.array());
+
+        // -- EOCD --
+        ByteBuffer eocd = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN);
+        eocd.putInt(0x06054b50);
+        eocd.putShort((short) 0);
+        eocd.putShort((short) 0);
+        eocd.putShort((short) 0xFFFF);
+        eocd.putShort((short) 0xFFFF);
+        eocd.putInt(0xFFFFFFFF);
+        eocd.putInt(0xFFFFFFFF);
+        eocd.putShort((short) 0);
+        out.write(eocd.array());
+
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
This read-only FileSystem implementation is designed to read classpath resources in Quarkus. It uses `RandomAccessFile` instead of `InterruptibleChannel` to avoid [JDK-8316882](https://bugs.openjdk.org/browse/JDK-8316882).

A more detailed description is added in the `README.md`.