### PR TITLE
Fix duplicate directory children when a sibling shares the directory name prefix

### DIFF
--- a/src/main/java/io/quarkus/fs/util/rozip/CompactEntryTable.java
+++ b/src/main/java/io/quarkus/fs/util/rozip/CompactEntryTable.java
@@ -5,7 +5,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A memory-efficient, immutable index of ZIP central directory entries.
@@ -384,17 +386,20 @@ final class CompactEntryTable {
             return null;
         }
 
+        // A directory entry's name has its trailing '/' stripped when stored (see the
+        // parsing loop), so an explicit directory entry (e.g. "a/b") can sort apart from
+        // the entries nested under it (e.g. "a/b/c") whenever a sibling shares the
+        // directory's name as a prefix (e.g. the file "a/b-x"). The same immediate child
+        // name can therefore be produced from non-adjacent positions, so deduplicate
+        // across the whole range rather than only collapsing consecutive duplicates.
         List<String> children = new ArrayList<>();
-        int prevStart = -1;
-        int prevLen = -1;
+        Set<String> seen = new HashSet<>();
         for (int i = start; i < entryCount && nameStartsWith(i, prefix); i++) {
             int childStart = nameOffsets[i] + prefix.length;
             int childLen = immediateChildLen(childStart, nameOffsets[i + 1]);
-            if (childLen != prevLen
-                    || !regionEquals(nameBytes, childStart, nameBytes, prevStart, childLen)) {
-                children.add(new String(nameBytes, childStart, childLen, StandardCharsets.UTF_8));
-                prevStart = childStart;
-                prevLen = childLen;
+            String child = new String(nameBytes, childStart, childLen, StandardCharsets.UTF_8);
+            if (seen.add(child)) {
+                children.add(child);
             }
         }
         return Collections.unmodifiableList(children);

--- a/src/test/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystemTest.java
+++ b/src/test/java/io/quarkus/fs/util/rozip/ReadOnlyZipFileSystemTest.java
@@ -142,6 +142,45 @@ class ReadOnlyZipFileSystemTest {
     }
 
     @Test
+    void listDirectoryWithPrefixSiblingFile() throws IOException {
+        // "menu" is a directory; "menu-sidebar.html" is a sibling file whose name
+        // starts with the directory name. The directory must be listed exactly once.
+        Path zip = createZip("test.zip",
+                entry("tags/menu/item.html", "i"),
+                entry("tags/menu/group.html", "g"),
+                entry("tags/menu-sidebar.html", "s"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                DirectoryStream<Path> stream = Files.newDirectoryStream(fs.getPath("/tags"))) {
+            List<String> names = new ArrayList<>();
+            stream.forEach(p -> names.add(p.getFileName().toString()));
+            Collections.sort(names);
+            assertEquals(List.of("menu", "menu-sidebar.html"), names);
+        }
+    }
+
+    @Test
+    void walkDirectoryTreeWithPrefixSiblingFile() throws IOException {
+        // Regression: a subdirectory whose name is a prefix of a sibling file
+        // (here "menu/" next to "menu-sidebar.html") was walked twice, yielding
+        // duplicate paths for everything under it. Includes explicit directory
+        // entries, as produced by the Maven jar plugin.
+        Path zip = createZip("test.zip",
+                entry("tags/", ""),
+                entry("tags/menu/", ""),
+                entry("tags/menu/item.html", "i"),
+                entry("tags/menu/group.html", "g"),
+                entry("tags/menu-sidebar.html", "s"));
+
+        try (FileSystem fs = ReadOnlyZipFileSystem.open(zip);
+                Stream<Path> stream = Files.walk(fs.getPath("/"))) {
+            List<String> paths = stream.map(Path::toString).collect(Collectors.toList());
+            List<String> distinct = paths.stream().distinct().collect(Collectors.toList());
+            assertEquals(distinct, paths, "Files.walk should not visit any path twice; got " + paths);
+        }
+    }
+
+    @Test
     void listDirectory() throws IOException {
         Path zip = createZip("test.zip",
                 entry("dir/alpha.txt", "a"),


### PR DESCRIPTION
## Problem

`CompactEntryTable` strips the trailing `/` from directory entry names before storing and sorting them (the parsing loop in `buildFromCentralDirectory`). As a result an explicit directory entry such as `a/b` is stored as `a/b`, which sorts **apart** from the entries nested under it (`a/b/c`) whenever a sibling shares the directory name as a prefix, for example the file `a/b-x`:

```
a/b           <- explicit directory entry (slash stripped) -> child "b"
a/b-x         <- sibling file                              -> child "b-x"
a/b/c         <- nested entry                              -> child "b"
```

(`-` is `0x2D`, `/` is `0x2F`, so `a/b-x` sorts between `a/b` and `a/b/c`.)

`getDirectoryChildren` deduplicated only **consecutive** duplicate child names, so the immediate child `b` was produced twice from non-adjacent positions and returned twice. `Files.walk` then descended into the `b` subtree twice, visiting every nested path twice.

## Impact

This surfaced downstream in Quarkus 3.36.1 (which adopted this read-only ZIP filesystem via [quarkusio/quarkus#54144]) as a Qute build failure:

```
io.quarkus.qute.deployment.QuteProcessor#collectEffectiveTemplatePaths:
java.lang.IllegalStateException: Duplicate templates found:
  - tags/menu/menu-item.html: [/templates/tags/menu/menu-item.html [10], /templates/tags/menu/menu-item.html [10]]
  ...
```

for any application whose dependency jar has a Qute tag directory (e.g. `tags/menu/`) sitting next to a prefix-sharing sibling file (e.g. `tags/menu-sidebar.html`).

## Fix

Deduplicate immediate child names across the whole prefix range instead of only collapsing consecutive duplicates.

## Tests

Adds two tests that fail before the change and pass after:
- `listDirectoryWithPrefixSiblingFile` — `newDirectoryStream` returns the directory exactly once.
- `walkDirectoryTreeWithPrefixSiblingFile` — `Files.walk` visits no path twice.

Full suite (111 tests) passes.

[quarkusio/quarkus#54144]: https://github.com/quarkusio/quarkus/pull/54144